### PR TITLE
Fireworks bug kinda fix

### DIFF
--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Firework/Firework.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Firework/Firework.as
@@ -176,11 +176,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	if (cmd == this.getCommandID("offblast"))
 	{
 		if (this.hasTag("offblast")) return;
-		if (this.isInInventory())
-		{
-			DoExplosion(this);
-			return;
-		}
 		// this.setPosition(this.getPosition() + Vec2f(0, -32)); // Hack
 		this.setAngleDegrees(0);
 		Vec2f pos = this.getPosition();
@@ -199,6 +194,11 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		this.SetLight(true);
 		this.SetLightRadius(128.0f);
 		this.SetLightColor(SColor(255, 255, 100, 0));
+		if (this.isInInventory())
+		{
+			DoExplosion(this);
+			return;
+		}
 	}
 }
 

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Firework/Firework.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Firework/Firework.as
@@ -176,7 +176,11 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	if (cmd == this.getCommandID("offblast"))
 	{
 		if (this.hasTag("offblast")) return;
-
+		if (this.isInInventory())
+		{
+			DoExplosion(this);
+			return;
+		}
 		// this.setPosition(this.getPosition() + Vec2f(0, -32)); // Hack
 		this.setAngleDegrees(0);
 		Vec2f pos = this.getPosition();
@@ -217,9 +221,3 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	
 	return damage;
 }
-
-
-
-
-
-			


### PR DESCRIPTION
Now fireworks explode immediately when launched from inventory (doing full damage to holder), which still allows kinda offensive use of fireworks (at a blood price) but is not as imbalanced as it was.

Idk maybe it'd be better to completely forbid igniting those in inventories but I'd say this way it's funnier.