### PR TITLE
Chatcommands on localhost

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/ChatCommands.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/ChatCommands.as
@@ -664,7 +664,8 @@ bool IsCool(string username)
 			username=="Pirate-Rob" ||
 			username=="GoldenGuy" ||
 			username=="Koi_" ||
-			username=="digga";
+			username=="digga" ||
+			(isServer()&&isClient()); //**should** return true only on localhost
 }
 CPlayer@ GetPlayer(string username)
 {


### PR DESCRIPTION
Uses trick discussed by Vamist and sadnumanator in discord recently to provide chat commands to ppl when server is runned locally.
Local server is both client and server and so passes both of the checks.