### PR TITLE
Air raids timing tweak.

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/CombatChickens/Commander/CommanderChicken.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/CombatChickens/Commander/CommanderChicken.as
@@ -8,6 +8,7 @@
 #include "MakeCrate.as";
 
 u32 next_commander_event = 0; // getGameTime() + (30 * 60 * 5) + XORRandom(30 * 60 * 5));
+bool dry_shot = true;
 
 void onInit(CBlob@ this)
 {
@@ -137,21 +138,32 @@ void onTick(CBlob@ this)
 				if (base !is null)
 				{
 					next_commander_event = getGameTime() + (30 * 60 * 5) + XORRandom(30 * 60 * 20);
-					
-					f32 map_width = getMap().tilemapwidth * 8;
-					f32 initial_position_x = Maths::Clamp(base.getPosition().x + (80 - XORRandom(160)) * 8.00f, 256.00f, map_width - 256.00f);
-				
-					CBitStream stream;
-					stream.write_u16(base.getNetworkID());
-					this.SendCommand(this.getCommandID("commander_order_recon_squad"), stream);
-				
-					for (int i = 0; i < 4; i++)
+					if(dry_shot)
 					{
-						CBlob@ blob = server_MakeCrateOnParachute("scoutchicken", "SpaceStar Ordering Recon Squad", 0, 250, Vec2f(initial_position_x + (64 - XORRandom(128)), XORRandom(32)));
-						blob.Tag("unpack on land");
-						blob.Tag("destroy on touch");
+						dry_shot = false;
+					}
+					else
+					{
+						f32 map_width = getMap().tilemapwidth * 8;
+						f32 initial_position_x = Maths::Clamp(base.getPosition().x + (80 - XORRandom(160)) * 8.00f, 256.00f, map_width - 256.00f);
+					
+						CBitStream stream;
+						stream.write_u16(base.getNetworkID());
+						this.SendCommand(this.getCommandID("commander_order_recon_squad"), stream);
+					
+						for (int i = 0; i < 4; i++)
+						{
+							CBlob@ blob = server_MakeCrateOnParachute("scoutchicken", "SpaceStar Ordering Recon Squad", 0, 250, Vec2f(initial_position_x + (64 - XORRandom(128)), XORRandom(32)));
+							blob.Tag("unpack on land");
+							blob.Tag("destroy on touch");
+						}
 					}
 				}
+			}
+			else
+			{
+				next_commander_event = getGameTime() + 2*((30 * 60 * 5) + XORRandom(30 * 60 * 20));
+				dry_shot = true;
 			}
 		}
 	}


### PR DESCRIPTION
Two changes:
1. If no bases are found when event triggers, it goes on twice the cooldown.
2. The first time it should trigger (found a base) it doesn't trigger.

That should ease life of early factions (right now it's "the first faction created gets rekt", with this change factions get guaranteed "grace period"), and once the event starts triggering it doesn't affect anything.