### PR TITLE
Small tweaks

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Characters/HurtOnCollide.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Characters/HurtOnCollide.as
@@ -55,7 +55,8 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal, Vec2f point
 			if (vellen > 0.1f &&
 			        this.getMass() > 1.0f &&
 			        (map.isTileCastle(tile) ||
-			         map.isTileWood(tile)))
+			         map.isTileWood(tile)) ||
+			         (tile>=394&&tile<=410 /*glass block*/))
 			{
 				f32 vellen = this.getShape().vellen;
 				f32 dmg = this.get_f32("map dmg modifier") * vellen * this.getMass() / 10000.0f;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Inserter/Inserter.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Inserter/Inserter.as
@@ -54,6 +54,7 @@ void onInit(CBlob@ this)
 	this.getShape().getConsts().mapCollisions = false;
 	this.getCurrentScript().tickFrequency = 60;
 	
+	this.Tag("ignore extractor");
 	this.Tag("builder always hit");
 	this.addCommandID("use");
 	


### PR DESCRIPTION
Changes HurtOnCollide to allow tanks to damage glass by ramming.
Tags inserters with "ignore extractor" to improve their ability to do stuff.