### PR TITLE
Forcefeeding and stuff

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Badger/Badger.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Badger/Badger.cfg
@@ -134,7 +134,7 @@ $name                                = badger
 									   GibIntoSteaks.as;
 									   IsFlammable.as;
 									   HOTHOTHOT.as;
-									   ForceFeedable.as;
+									   ForceFeed.as;
 f32 health                           = 7.0
 # looks & behaviour inside inventory
 $inventory_name                      = An Upset Badger

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Bagel/Bagel.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Bagel/Bagel.cfg
@@ -134,7 +134,7 @@ $name                                = bagel
 									   GibIntoSteaks.as;
 									   IsFlammable.as;
 									   HOTHOTHOT.as;
-									   ForceFeedable.as;
+									   ForceFeed.as;
 f32 health                           = 18.0
 # looks & behaviour inside inventory
 $inventory_name                      = Disased Bagel

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Cowo/Cowo.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Cowo/Cowo.cfg
@@ -133,7 +133,7 @@ $name                                = cowo
 									   FleshHitEffects.as;
 									   FleshHit.as;
 									   IsFlammable.as;
-									   ForceFeedable.as;
+									   ForceFeed.as;
 f32 health                           = 25.0
 # looks & behaviour inside inventory
 $inventory_name                      = Cowo

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Cuck/Cuck.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Cuck/Cuck.cfg
@@ -128,7 +128,7 @@ $name                                             = cuck
 													RunnerDeath.as; # this checks for "dead" so leave it last
 													ActivateHeldObject.as;
 													RunnerActivateable.as;
-													ForceFeedable.as;
+													ForceFeed.as;
 f32 health                                        = 25.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Cuck

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hobo/Hobo.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hobo/Hobo.cfg
@@ -116,7 +116,7 @@ $name                                             = hobo
                                                     FallSounds.as;
                                                     RunnerDrowning.as; # after redflash so it overrides the flash
                                                     FleshHit.as; # this gibs so leave it last		
-													ForceFeedable.as;													
+													ForceFeed.as;													
 f32 health                                        = 3.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Smelly Hobo

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Kitten/Kitten.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Kitten/Kitten.cfg
@@ -106,7 +106,7 @@ $name                                      = kitten
 											 IsFlammable.as;
 											 HOTHOTHOT.as;
 											 FallDamage.as;
-											 ForceFeedable.as;
+											 ForceFeed.as;
 f32 health                                 = 1.7
 # looks & behaviour inside inventory
 $inventory_name                            = Kitten

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Pus/Pus.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Pus/Pus.cfg
@@ -109,7 +109,7 @@ $name                                             = pus
 													Stomp.as;
 													RunnerDrowning.as; # after redflash so it overrides the flash
 													RunnerDeath.as; # this checks for "dead" so leave it last
-													ForceFeedable.as;
+													ForceFeed.as;
 f32 health                                        = 6.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Pus

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Trader/Trader.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Trader/Trader.cfg
@@ -117,7 +117,7 @@ $name                                             = trader
                                                     FallSounds.as;
                                                     RunnerDrowning.as; # after redflash so it overrides the flash
                                                     FleshHit.as; # this gibs so leave it last			
-													ForceFeedable.as;	
+													ForceFeed.as;	
 f32 health                                        = 4.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Trader

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Villager/VillagerMale.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Villager/VillagerMale.cfg
@@ -117,7 +117,7 @@ $name                                             = villagermale
                                                     FallSounds.as;
                                                     RunnerDrowning.as; # after redflash so it overrides the flash
                                                     FleshHit.as; # this gibs so leave it last	
-													ForceFeedable.as;													
+													ForceFeed.as;													
 f32 health                                        = 5.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Lawyer

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/ForceFeed.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/ForceFeed.as
@@ -23,7 +23,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 bool canBeForceFed(CBlob@ this)
 {
-	return (getKnocked(this) > 0) || (this.get_f32("babbyed") > 0) || (this.isKeyPressed(key_down));
+	return (getKnocked(this) > 0) || (this.get_f32("babbyed") > 0) || (this.isKeyPressed(key_down)) || (this.getPlayer() is null);
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)


### PR DESCRIPTION
Changed ForceFeedable.as to ForceFeed.as as I suppose it was intended to make these npcs valid targets for forcefeeding, not forcefeedable objects. Also made playerless blobs forcefeedable (i.e. no need to knock badger to feed it unless it's controlled by player).