### PR TITLE
Fixed bomber consuming no fuel when above abyss

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/BomberCommon.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/BomberCommon.as
@@ -142,7 +142,7 @@ s32 getHeight(CBlob@ this)
 	{
 		return Maths::Max((point.y - pos.y - 16) / 8.00f, 0);
 	}
-	else return 0;
+	else return map.tilemapheight+50-pos.y/8;
 }
 
 void drawFuelCount(CBlob@ this)


### PR DESCRIPTION
Now if raycast is failed it assumes it's height as current height above map's floor + 50 tiles, not sure if 50 tiles fits, but I'd say it's ok.