### PR TITLE
structure placing qol

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/AddTilesBySector.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/AddTilesBySector.as
@@ -1,0 +1,45 @@
+void AddTilesBySector(Vec2f ul, Vec2f lr, string sectorName, TileType tile, TileType omitTile = 255)
+{
+	if (getNet().isServer())
+	{
+		CMap@ map = getMap();
+		const f32 tilesize = map.tilesize;
+		Vec2f tpos = ul;
+		while (tpos.x < lr.x)
+		{
+			while (tpos.y < lr.y)
+			{
+				if (map.getSectorAtPosition(tpos, sectorName) !is null && map.getTile(tpos).type != omitTile)
+				{
+					map.server_SetTile(tpos, tile);
+				}
+				tpos.y += tilesize;
+			}
+			tpos.x += tilesize;
+			tpos.y = ul.y;
+		}
+	}
+}
+
+void AddTilesBySectorSoft(Vec2f ul, Vec2f lr, string sectorName, TileType tile)
+{
+	if (getNet().isServer())
+	{
+		CMap@ map = getMap();
+		const f32 tilesize = map.tilesize;
+		Vec2f tpos = ul;
+		while (tpos.x < lr.x)
+		{
+			while (tpos.y < lr.y)
+			{
+				if (map.getSectorAtPosition(tpos, sectorName) !is null && map.getTile(tpos).type < tile)
+				{
+					map.server_SetTile(tpos, tile);
+				}
+				tpos.y += tilesize;
+			}
+			tpos.x += tilesize;
+			tpos.y = ul.y;
+		}
+	}
+}

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/DefaultNoBuild.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/DefaultNoBuild.as
@@ -48,7 +48,7 @@ void onTick(CBlob@ this)
 
 		if (this.exists(back))
 		{
-			AddTilesBySector(ul, lr, "no build", this.get_TileType(back), CMap::tile_castle_back);
+			AddTilesBySectorSoft(ul, lr, "no build", this.get_TileType(back));
 		}
 		else
 			this.getCurrentScript().runFlags |= Script::remove_after_this;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/TileBackground.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/TileBackground.as
@@ -1,0 +1,25 @@
+// Blame Fuzzle.
+
+#define SERVER_ONLY
+
+void onSetStatic(CBlob@ this, const bool isStatic)
+{
+
+	if (!isStatic)
+		return;
+
+	if (this.exists("background tile"))
+	{
+
+		CMap@ map = getMap();
+		Vec2f position = this.getPosition();
+		const u16 type = this.get_TileType("background tile");
+
+		if (map.getTile(position).type < type) //implies that higher type means harder material (and who ever sets broken tiles as background?)
+			map.server_SetTile(position, type);
+
+	}
+
+	this.getCurrentScript().runFlags |= Script::remove_after_this;
+
+}

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Building/DefaultBuilding.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Building/DefaultBuilding.as
@@ -1,5 +1,7 @@
 ﻿// A default building init script
 
+#include "CustomBlocks.as";
+
 const f32 allow_overlap = 2.0f;
 
 void onInit(CBlob@ this)
@@ -21,7 +23,7 @@ void onTick(CBlob@ this)
 	{
 		// make window
 		Vec2f tilepos = this.getPosition() - Vec2f(0, 4);
-		getMap().server_SetTile(tilepos, CMap::tile_empty);
+		getMap().server_SetTile(tilepos, CMap::tile_bglass);
 
 		//check for overlapping buildings
 		CBlob@[] buildings;


### PR DESCRIPTION
Makes structures with background tiles respect already placed backgrounds (order of tiles in world.png is a bit fucked up, but as there are currently no buildings with non-stone background it works as intended) + changes "window" in such backgrounds to bglass (instead of empty)