### PR TITLE
OMG HOBOS BUFF

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/DeadCantTrade.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/DeadCantTrade.as
@@ -1,0 +1,9 @@
+f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
+{
+	if (this.hasTag("dead"))
+	{
+		this.set_bool("shop available", false);
+	}
+	
+	return damage;
+}

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hobo/Hobo.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hobo/Hobo.as
@@ -577,22 +577,6 @@ void onGib(CSprite@ this)
 	CParticle@ Gib3 = makeGibParticle("Entities/Special/WAR/Trading/TraderGibs.png", pos, vel + getRandomVelocity(90, hp, 80), 2, 0, Vec2f(16, 16), 2.0f, 0, "/BodyGibFall");
 }
 
-void onHealthChange(CBlob@ this, f32 oldHealth)
-{
-	if (this.getHealth() < 1.0f && !this.hasTag("dead"))
-	{
-		this.Tag("dead");
-		this.set_bool("shop available", false);
-		// this.server_SetTimeToDie(20);
-	}
-
-	if (this.getHealth() < 0)
-	{
-		this.getSprite().Gib();
-		this.server_Die();
-		return;
-	}
-}
 
 bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 {

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hobo/Hobo.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hobo/Hobo.cfg
@@ -112,25 +112,27 @@ $inventory_name                                   = Hobo
 
 $name                                             = hobo
 @$scripts                                         = RunnerDefault.as;
-													StandardControls.as;
-													StandardPickup.as;
-													DetectLadder.as; #resets ladder, put before other code that uses ladder
-													Shop.as;
-													Hobo.as;
-													FleshHitEffects.as;
-													FleshHit.as;
-													RunnerCollision.as;
-													FallDamage.as;
-													FallSounds.as;
-													HurtOnCollide.as;
-													EmoteHotkeys.as;
-													Stomp.as;
-													EmoteBubble.as;
-													RunnerDrowning.as; # after redflash so it overrides the flash
-													RunnerDeath.as; # this checks for "dead" so leave it last
-													ActivateHeldObject.as;
-													RunnerActivateable.as;
-													ForceFeed.as;											
+                                                    StandardControls.as;
+                                                    StandardPickup.as;
+                                                    DetectLadder.as; #resets ladder, put before other code that uses ladder
+                                                    Shop.as;
+                                                    Hobo.as;
+                                                    FleshHitEffects.as;
+                                                    FleshHit.as;
+                                                    RunnerCollision.as;
+                                                    FallDamage.as;
+                                                    FallSounds.as;
+                                                    HurtOnCollide.as;
+                                                    EmoteHotkeys.as;
+                                                    Stomp.as;
+                                                    EmoteBubble.as;
+                                                    RunnerDrowning.as; # after redflash so it overrides the flash
+                                                    RunnerDeath.as; # this checks for "dead" so leave it last
+                                                    ActivateHeldObject.as;
+                                                    RunnerActivateable.as;
+                                                    ForceFeed.as;
+                                                    DeadCantTrade.as;
+										
 f32 health                                        = 3.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Smelly Hobo

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hoob/Hoob.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hoob/Hoob.as
@@ -143,13 +143,7 @@ void onTick(CBlob@ this)
 	if (!this.hasTag("dead"))
 	{	
 		bool client = isClient();
-		bool server = isServer();		
-	
-		if (this.getHealth() <= 0)
-		{
-			this.Tag("dead");		
-			return;
-		}
+		bool server = isServer();
 
 		RunnerMoveVars@ moveVars;
 		if (this.get("moveVars", @moveVars))

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hoob/Hoob.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Hoob/Hoob.cfg
@@ -104,8 +104,8 @@ $inventory_factory                                =
 $name                                             = hoob
 @$scripts                                         = RunnerDefault.as;
                                                     StandardControls.as;
-													StandardPickup.as;
-													Hoob.as;
+                                                    StandardPickup.as;
+                                                    Hoob.as;
                                                     DetectLadder.as; #resets ladder, put before other code that uses ladder
                                                     RunnerCollision.as;
                                                     IsFlammable.as;
@@ -116,10 +116,12 @@ $name                                             = hoob
                                                     FallDamage.as;
                                                     Stomp.as;
                                                     FallSounds.as;
-													EmoteBubble.as;
+                                                    EmoteBubble.as;
                                                     RunnerDrowning.as; # after redflash so it overrides the flash
                                                     FleshHit.as; # this gibs so leave it last		
-													ForceFeed.as;													
+                                                    ForceFeed.as;
+                                                    RunnerDeath.as;
+				
 f32 health                                        = 25.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Fetid Hoob

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Trader/Trader.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Trader/Trader.as
@@ -401,23 +401,6 @@ void onGib(CSprite@ this)
 	CParticle@ Gib3 = makeGibParticle("Entities/Special/WAR/Trading/TraderGibs.png", pos, vel + getRandomVelocity(90, hp, 80), 2, 0, Vec2f(16, 16), 2.0f, 0, "/BodyGibFall");
 }
 
-void onHealthChange(CBlob@ this, f32 oldHealth)
-{
-	if (this.getHealth() < 1.0f && !this.hasTag("dead"))
-	{
-		this.Tag("dead");
-		this.set_bool("shop available", false);
-		// this.server_SetTimeToDie(20);
-	}
-
-	if (this.getHealth() < 0)
-	{
-		this.getSprite().Gib();
-		this.server_Die();
-		return;
-	}
-}
-
 bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 {
 	// if (byBlob.getTeamNum() != this.getTeamNum()) return true;

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Trader/Trader.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Trader/Trader.cfg
@@ -102,9 +102,9 @@ $inventory_factory                                =
 $name                                             = trader
 @$scripts                                         = RunnerDefault.as;
                                                     StandardControls.as;
-													Shop.as;
-													Trader.as;
-													SetTeamToCarrier.as;
+                                                    Shop.as;
+                                                    Trader.as;
+                                                    SetTeamToCarrier.as;
                                                     DetectLadder.as; #resets ladder, put before other code that uses ladder
                                                     RunnerCollision.as;
                                                     IsFlammable.as;
@@ -116,8 +116,10 @@ $name                                             = trader
                                                     Stomp.as;
                                                     FallSounds.as;
                                                     RunnerDrowning.as; # after redflash so it overrides the flash
-                                                    FleshHit.as; # this gibs so leave it last			
-													ForceFeed.as;	
+                                                    FleshHit.as; # this gibs so leave it last
+                                                    RunnerDeath.as;
+                                                    DeadCantTrade.as;
+                                                    ForceFeed.as;	
 f32 health                                        = 4.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Trader


### PR DESCRIPTION
Idk why npc death was coded in such way, but it was cursed af and caused players controlling hobos to be unable to respawn until **corpse** of the hobo is destroyed.
So, I moved all the stuff to already implemented in vanilla RunnerDeath.as and added DeadCantTrade.as with custom onHit hook to remove shops from corpses.
As a side effect hobos got 1.5 hp buff (because it was dedicated to corpse health before), and now their health bar correctly shows their real hp.

Also ffs why did .cfg formatting contained both tabs and spaces as identation