### PR TITLE
Many faction changes

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
@@ -137,8 +137,7 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 				if (!fail && b.name == "camp")
 				{
 					CBlob@[] blobs;
-					getBlobsByName("camp", @blobs);
-					getBlobsByName("fortress", @blobs);
+					getBlobsByTag("faction_base", @blobs);
 					for (int i = 0; i < blobs.length; i++)
 					{
 						CBlob@ e = blobs[i];
@@ -147,7 +146,7 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 						if(e.getTeamNum() != this.getTeamNum() && distance <= 256)
 						{
 							fail = true;
-							print("there is enemy camp/fortress near!");
+							//print("there is enemy faction base near!"); //why is it even here it doesn't write to chat
 							break;
 						}
 					}

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
@@ -146,7 +146,7 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 						if(e.getTeamNum() != this.getTeamNum() && distance <= 256)
 						{
 							fail = true;
-							//print("there is enemy faction base near!"); //why is it even here it doesn't write to chat
+							if (this.isMyPlayer()) client_AddToChat("There is an enemy faction base near!", SColor(0xff444444));
 							break;
 						}
 					}

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Peasant/PeasantInventory.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Peasant/PeasantInventory.as
@@ -184,8 +184,7 @@ void onCreateInventoryMenu(CInventory@ this, CBlob@ forBlob, CGridMenu@ menu)
 	blob.ClearGridMenusExceptInventory();
 
 	CBlob@[] forts;
-	getBlobsByName("fortress", @forts);
-	getBlobsByName("camp", @forts);
+	getBlobsByTag("faction_base", @forts);
 					
 	u8[] teamForts = {0, 0, 0, 0, 0, 0, 0, 0};
 	u8[] emptyTeams;

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Slave/SlaveInventory.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Slave/SlaveInventory.as
@@ -183,8 +183,7 @@ void onCreateInventoryMenu(CInventory@ this, CBlob@ forBlob, CGridMenu@ menu)
 	blob.ClearGridMenusExceptInventory();
 
 	CBlob@[] forts;
-	getBlobsByName("fortress", @forts);
-	getBlobsByName("camp", @forts);
+	getBlobsByTag("faction_base", @forts);
 					
 	u8[] teamForts = {0, 0, 0, 0, 0, 0, 0, 0};
 	u8[] emptyTeams;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
@@ -5,7 +5,7 @@
 const string counter_prop = "capture ticks";
 const string raid_tag = "under raid";
 const string chicken_tag = "chicken raid";
-const string reinforcements_tag = "can respawn";
+const string reinforcements_tag = "reinforcements allowed";
 
 // const u16 capture_seconds = 10;
 const u16 capture_radius = 48;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
@@ -5,6 +5,7 @@
 const string counter_prop = "capture ticks";
 const string raid_tag = "under raid";
 const string chicken_tag = "chicken raid";
+const string reinforcements_tag = "can respawn";
 
 // const u16 capture_seconds = 10;
 const u16 capture_radius = 48;
@@ -110,6 +111,11 @@ void onTick(CBlob@ this)
 
 			this.set_s16(counter_prop, ticks);
 			this.Tag(raid_tag);
+			if (attackersCount > friendlyCount) {
+				this.Untag(reinforcements_tag);
+			} else {
+				this.Tag(reinforcements_tag);
+			}
 
 			if (ticks <= 0 && friendlyCount == 0)
 			{
@@ -144,6 +150,7 @@ void onTick(CBlob@ this)
 	{
 		this.Untag(raid_tag);
 		this.Untag(chicken_tag);
+		this.Tag(reinforcements_tag);
 	}
 
 	if (reset_timer)
@@ -156,6 +163,7 @@ void onTick(CBlob@ this)
 		this.set_s16(counter_prop, capture_seconds);
 		this.Untag(raid_tag);
 		this.Untag(chicken_tag);
+		this.Tag(reinforcements_tag);
 		
 		sync = true;
 	}

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
@@ -86,10 +86,6 @@ void onTick(CBlob@ this)
 				}
 			}
 		}
-		
-		if(friendlyCount > 0){
-			this.set_u16("last_friendly_visit",getGameTime());
-		}
 
 		u32 capture_seconds = getCaptureSeconds(this);
 		
@@ -104,7 +100,7 @@ void onTick(CBlob@ this)
 			//convert
 			if (attackersCount > friendlyCount)
 			{
-				ticks--;
+				ticks = Maths::Max(ticks - 1, 0);
 			}
 			//un-convert gradually
 			else if (attackersCount < friendlyCount || attackersCount == 0)
@@ -115,7 +111,7 @@ void onTick(CBlob@ this)
 			this.set_s16(counter_prop, ticks);
 			this.Tag(raid_tag);
 
-			if (ticks <= 0)
+			if (ticks <= 0 && friendlyCount == 0)
 			{
 				if (this.hasTag(chicken_tag) && (this.getName() == "citadel" || this.getName() == "fortress" || this.getName() == "camp"))
 				{

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
@@ -24,7 +24,7 @@ void onInit(CBlob@ this)
 	this.set_s16(friendly_prop, 0);
 	this.set_s16(enemy_prop, 0);
 	
-	// this.set_u16("last_friendly_visit",getGameTime());
+	this.set_u16("last_friendly_visit",getGameTime());
 	
 	this.Tag("capturable");
 }
@@ -80,16 +80,16 @@ void onTick(CBlob@ this)
 						if (b.hasTag("combat chicken")) this.Tag(chicken_tag);
 					}
 				}
-				// else if((b.getTeamNum()>=0 && b.getTeamNum()<7) || this.hasTag("can be captured by neutral")) 
-				// {
-					// friendlyCount++;
-				// }
+				else if((b.getTeamNum()>=0 && b.getTeamNum()<7) || this.hasTag("can be captured by neutral")) 
+				{
+					friendlyCount++;
+				}
 			}
 		}
 		
-		// if(friendlyCount > 0){
-			// this.set_u16("last_friendly_visit",getGameTime());
-		// }
+		if(friendlyCount > 0){
+			this.set_u16("last_friendly_visit",getGameTime());
+		}
 
 		u32 capture_seconds = getCaptureSeconds(this);
 		

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatHop.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatHop.as
@@ -24,7 +24,7 @@ void onTick(CBlob@ this)
 		{
 			CBlob @blob = blobsInRadius[i];
 
-			if ((blob !is this) && blob.hasTag("seats") &&  blob !is carried && (blob.getTeamNum() > 8 || blob.getTeamNum() == this.getTeamNum() || blob.hasTag("usable by anyone")))
+			if ((blob !is this) && blob.hasTag("seats") &&  blob !is carried && (blob.getTeamNum() > 8 && blob.getTeamNum() != 250 || blob.getTeamNum() == this.getTeamNum() || blob.hasTag("usable by anyone")))
 			{
 				//can't get into carried blob - can pick it up after they get in though
 				//(prevents dinghy rockets)

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatHop.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatHop.as
@@ -77,7 +77,7 @@ void onTick(CBlob@ this)
 		if (closestAP !is null)
 		{
 			closestAP.getBlob().server_AttachTo(this, closestAP);
-			if (isServer()) closestAP.getBlob().server_setTeamNum(this.getTeamNum());
+			if (isServer() && (closestAP.name == "FLYER" || closestAP.name == "DRIVER")) closestAP.getBlob().server_setTeamNum(this.getTeamNum());
 		}
 	}
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/VehicleConvert.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/VehicleConvert.as
@@ -1,0 +1,231 @@
+/*
+ * convertible if enemy outnumbers friends in radius
+ */
+
+const string counter_prop = "capture ticks";
+const string raid_tag = "under raid";
+const int capture_half_seconds = 30;
+const int short_capture_half_seconds = 10;
+const int capture_radius = 80;
+
+const string friendly_prop = "capture friendly count";
+const string enemy_prop = "capture enemy count";
+
+const string short_raid_tag = "short raid time";
+
+void onInit(CBlob@ this)
+{
+	this.addCommandID("convert");
+	this.getCurrentScript().tickFrequency = 15;
+	this.set_s16(counter_prop, GetCaptureTime(this));
+	this.set_s16(friendly_prop, 0);
+	this.set_s16(enemy_prop, 0);
+}
+
+//add
+void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
+{
+	if (!this.hasTag("convert on sit"))
+		return;
+
+	if (attachedPoint.socket &&
+	        attached.getTeamNum() != this.getTeamNum() &&
+	        attached.hasTag("player"))
+	{
+		this.server_setTeamNum(attached.getTeamNum());
+	}
+}
+
+void onTick(CBlob@ this)
+{
+	if (!getNet().isServer()) return;
+
+	bool reset_timer = true;
+	bool sync = false;
+
+	CBlob@[] blobsInRadius;
+	if (this.getMap().getBlobsInRadius(this.getPosition(), capture_radius, @blobsInRadius))
+	{
+		// count friendlies and enemies
+		int attackersCount = 0;
+		int friendlyCount = 0;
+
+		int attackerTeam = 255;
+		Vec2f pos = this.getPosition();
+		for (uint i = 0; i < blobsInRadius.length; i++)
+		{
+			CBlob @b = blobsInRadius[i];
+			if (b !is this && b.hasTag("player") && !b.hasTag("dead"))
+			{
+				if (b.getTeamNum() != this.getTeamNum())
+				{
+					Vec2f bpos = b.getPosition();
+					if (bpos.x > pos.x - this.getWidth() / 1.0f && bpos.x < pos.x + this.getWidth() / 1.0f &&
+					        bpos.y < pos.y + this.getHeight() / 1.0f && bpos.y > pos.y - this.getHeight() / 1.0f)
+					{
+						attackersCount++;
+						attackerTeam = b.getTeamNum();
+					}
+				}
+				else
+				{
+					friendlyCount++;
+				}
+			}
+		}
+
+		int ticks = GetCaptureTime(this);
+		if (this.hasTag(raid_tag))
+		{
+			ticks = this.get_s16(counter_prop);
+		}
+
+		if (attackersCount > 0 || ticks < GetCaptureTime(this))
+		{
+			//convert
+			if (attackersCount > friendlyCount)
+			{
+				ticks = Maths::Max(ticks - 1, 0);
+			}
+			//un-convert gradually
+			else if (attackersCount < friendlyCount || attackersCount == 0)
+			{
+				ticks = Maths::Min(ticks + 1, GetCaptureTime(this));
+			}
+
+			this.set_s16(counter_prop, ticks);
+			this.Tag(raid_tag);
+
+			if (ticks <= 0 && friendlyCount == 0)
+			{
+				this.server_setTeamNum(attackerTeam);
+				reset_timer = true;
+			}
+			else
+			{
+				this.set_s16(friendly_prop, friendlyCount);
+				this.set_s16(enemy_prop, attackersCount);
+				reset_timer = false;
+			}
+
+			sync = true;
+		}
+	}
+	else
+	{
+		this.Untag(raid_tag);
+	}
+
+	if (reset_timer)
+	{
+		this.set_s16(friendly_prop, 0);
+		this.set_s16(enemy_prop, 0);
+
+		this.set_s16(counter_prop, GetCaptureTime(this));
+		this.Untag(raid_tag);
+		sync = true;
+	}
+
+	if (sync)
+	{
+		this.Sync(friendly_prop, true);
+		this.Sync(enemy_prop, true);
+
+		this.Sync(counter_prop, true);
+		this.Sync(raid_tag, true);
+	}
+
+}
+
+void onChangeTeam(CBlob@ this, const int oldTeam)
+{
+	if (this.getTeamNum() >= 0 && this.getTeamNum() < 10)
+	{
+		CSprite@ sprite = this.getSprite();
+		if (sprite !is null)
+		{
+			sprite.PlaySound("/VehicleCapture");
+		}
+
+		ConvertPoint(this, "VEHICLE");
+		ConvertPoint(this, "DOOR");
+	}
+}
+
+void ConvertPoint(CBlob@ this, const string pointName)
+{
+	AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName(pointName);
+	if (point !is null)
+	{
+		CBlob@ blob = point.getOccupied();
+		if (blob !is null)
+		{
+			blob.server_setTeamNum(this.getTeamNum());
+		}
+	}
+}
+
+int GetCaptureTime(CBlob@ blob)
+{
+	if (blob.hasTag(short_raid_tag))
+	{
+		return short_capture_half_seconds;
+	}
+	return capture_half_seconds;
+}
+
+
+// alert and capture progress bar
+
+void onRender(CSprite@ this)
+{
+	if (g_videorecording)
+		return;
+
+	CBlob@ blob = this.getBlob();
+	CCamera@ camera = getCamera();
+	if (blob is null || !blob.hasTag(raid_tag))
+		return;
+
+	Vec2f pos2d = getDriver().getScreenPosFromWorldPos(blob.getPosition());
+
+	s16 friendlyCount = blob.get_s16(friendly_prop);
+	s16 enemyCount = blob.get_s16(enemy_prop);
+
+	f32 hwidth = 45 + Maths::Max(0, Maths::Max(friendlyCount, enemyCount) - 3) * 8;
+	f32 hheight = 30;
+
+	if (camera.targetDistance > 0.9) 			//draw bigger capture bar if zoomed in
+	{
+		pos2d.y -= 40;
+	 	f32 padding = 4.0f;
+	 	f32 shift = 29.0f;
+	 	s32 captureTime = blob.get_s16(counter_prop);
+	 	f32 progress = (1.1f - float(captureTime) / float(GetCaptureTime(blob)))*(hwidth*2-13); //13 is a magic number used to perfectly align progress
+	 	GUI::DrawPane(Vec2f(pos2d.x - hwidth + padding, pos2d.y + hheight - shift - padding),
+	 		      Vec2f(pos2d.x + hwidth - padding, pos2d.y + hheight - padding),
+			      SColor(175,200,207,197)); 				//draw capture bar background
+		if (progress >= float(8)) 					//draw progress if capture can start
+		{
+	 		GUI::DrawPane(Vec2f(pos2d.x - hwidth + padding, pos2d.y + hheight - shift - padding),
+			      	      Vec2f((pos2d.x - hwidth + padding) + progress, pos2d.y + hheight - padding),
+				      SColor(175,200,207,197));
+		}
+		//draw balance of power
+		for (int i = 1; i <= friendlyCount; i++)
+	 		GUI::DrawIcon("VehicleConvertIcon.png", 0, Vec2f(8, 16), pos2d + Vec2f(i * 8 - 8, -4), 0.9f, blob.getTeamNum());
+	 	for (int i = 1; i <= enemyCount; i++)
+	 		GUI::DrawIcon("VehicleConvertIcon.png", 1, Vec2f(8, 16), pos2d + Vec2f(i * -8 - 8, -4), 0.9f);
+	}
+	else
+	{
+		//draw smaller capture bar if zoom is farthest
+		pos2d.y -= 37;
+		f32 padding = 2.0f;
+ 		s32 captureTime = blob.get_s16(counter_prop);
+ 		GUI::DrawProgressBar(Vec2f(pos2d.x - hwidth / 2, pos2d.y + hheight - 14 - padding),
+ 	                      	     Vec2f(pos2d.x + hwidth / 2, pos2d.y + hheight - padding),
+ 	                      	     1.0f - float(captureTime) / float(GetCaptureTime(blob)));
+	}
+
+}

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
@@ -332,7 +332,7 @@ void onTick(CRules@ this)
 						if (base !is null && base.getTeamNum() == team)
 						{
 							has_bases = true;
-							if (base.hasTag("under raid")) continue;
+							if (!base.hasTag("can respawn")) continue;
 							spawns.push_back(bases[i]);
 						}
 					}

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
@@ -7,6 +7,8 @@
 #include "Logging.as";
 // #include "Knocked.as"
 
+#include "neutral_team_assigner.as"
+
 shared class Players
 {
 	CTFPlayerInfo@[] list;
@@ -390,7 +392,8 @@ void onTick(CRules@ this)
 				// Bandit scum spawning
 				if (isNeutral)
 				{
-					team = 100 + XORRandom(100);
+					string playerName = player.getUsername().split('~')[0];
+					team = reserve_team(playerName);
 					player.server_setTeamNum(team);
 
 					string blobType = "peasant";

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
@@ -332,7 +332,7 @@ void onTick(CRules@ this)
 						if (base !is null && base.getTeamNum() == team)
 						{
 							has_bases = true;
-							if (!base.hasTag("can respawn")) continue;
+							if (!base.hasTag("reinforcements allowed")) continue;
 							spawns.push_back(bases[i]);
 						}
 					}

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
@@ -256,7 +256,7 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ attacker, u8 customData
 			f32 upkeep_ratio = f32(upkeep) / f32(upkeep_cap);
 
 			if (upkeep_ratio >= UPKEEP_RATIO_PENALTY_RESPAWN_TIME) respawn_time += 30 * 4;
-			if (upkeep_ratio >= UPKEEP_RATIO_BONUS_RESPAWN_TIME) respawn_time -= 30 * 2;
+			if (upkeep_ratio <= UPKEEP_RATIO_BONUS_RESPAWN_TIME) respawn_time -= 30 * 2;
 		}
 	}
 

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
@@ -325,12 +325,14 @@ void onTick(CRules@ this)
 					getBlobsByTag("faction_base", @bases);
 					getBlobsByTag("respawn", @bases);
 					CBlob@[] spawns;
-
+					bool has_bases = false;
 					for (uint i = 0; i < bases.length; i++)
 					{
 						CBlob@ base = bases[i];
 						if (base !is null && base.getTeamNum() == team)
 						{
+							has_bases = true;
+							if (base.hasTag("under raid")) continue;
 							spawns.push_back(bases[i]);
 						}
 					}
@@ -385,6 +387,7 @@ void onTick(CRules@ this)
 					}
 					else
 					{
+						if (has_bases) return; //wait until able to spawn or lost all bases
 						isNeutral = true; // In case if the player is respawning while the team has been defeated
 					}
 				}

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/neutral_team_assigner.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/neutral_team_assigner.as
@@ -1,0 +1,35 @@
+#ifndef __neutral_team_assigner
+#define __neutral_team_assigner
+
+const uint min_team = 100; //neutrals //getRules().getTeamsNum();
+const uint max_team = 250; //chickens
+
+//ok let's be real
+//TC is not getting more than 20 players
+//entire KAG doesn't have more than 100 players playing at the same time
+//which means there's no real reason to implement dynamic team binding/unbinding
+//also no reason to respect max team num
+
+uint reserve_team(string playername) {
+	if (!isServer()) return min_team;
+	if (playername == "jammer312") {
+		return max_team - 1; //why not?
+	}
+	dictionary @bindings;
+	CRules @rules = getRules();
+	if (!rules.get("_neutral_team_bindings", @bindings)) @bindings = @dictionary();
+	uint team = min_team;
+	uint tmp; //dictionary::get corrupts handle even if it fails to retrieve data
+	if (bindings.get("min", tmp)) team = tmp;
+	if (bindings.get("_" + playername, tmp)) team = tmp;
+	else {
+		bindings.set("_" + playername, team);
+		bindings.set("min", team + 1);
+		// print("reserving team "+team);
+	}
+	rules.set("_neutral_team_bindings", @bindings);
+	// print("returning team "+team);
+	return team;
+}
+
+#endif

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/CommonFactionBuilding.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/CommonFactionBuilding.as
@@ -2,6 +2,8 @@
 #include "Hitters.as";
 #include "Logging.as";
 
+#include "uncap_team.as"
+
 const string raid_tag = "under raid";
 const u32[] teamcolours = {0xff0000ff, 0xffff0000, 0xff00ff00, 0xffff00ff, 0xffff6600, 0xff00ffff, 0xff6600ff, 0xff647160};
 
@@ -774,6 +776,18 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ inParams)
 		}
 	}
 	
+	if (isServer()) {
+		if (cmd == this.getCommandID("faction_captured") || cmd == this.getCommandID("faction_destroyed")) {
+			int team = inParams.read_s32();
+			if (cmd == this.getCommandID("faction_captured")) {
+				team = inParams.read_s32();
+				bool defeat = inParams.read_bool();
+				if (!defeat) return;
+			}
+			uncap_team(team);
+		}
+	}
+
 
 	if (isClient())
 	{

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/LWS/LWS.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/LWS/LWS.cfg
@@ -73,6 +73,8 @@ $name                                      = lws
 											 SecurityLinkable.as;
 											 CollidesOnlyWithLarger.as;
 											 OwnedByUPF.as;
+											 noncapturable.as;
+
 f32_health                                 = 16.0
 # looks & behaviour inside inventory
 $inventory_name                            = LWS

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SAM/SAM.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SAM/SAM.cfg
@@ -73,6 +73,8 @@ $name                                      = sam
 											 SecurityLinkable.as;
 											 CollidesOnlyWithLarger.as;
 											 OwnedByUPF.as;
+											 noncapturable.as;
+
 f32_health                                 = 16.0
 # looks & behaviour inside inventory
 $inventory_name                            = SAM Launcher

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Tunnel/TunnelTravel.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Tunnel/TunnelTravel.as
@@ -156,16 +156,15 @@ void Travel(CBlob@ this, CBlob@ caller, Vec2f position, bool vulnerable)
 			Sound::Play("Travel.ogg", this.getPosition());
 			Sound::Play("Travel.ogg", caller.getPosition());
 		}
-		//stunned on going through tunnel
-		//(prevents tunnel spam and ensures traps get you)
+		//invuln strip
 		if (vulnerable && isKnockable(caller))
 		{
 			//if you travel, you lose invincible
 			caller.Untag("invincible");
 			caller.Sync("invincible", true);
 
-			//actually do the knocking
-			setKnocked(caller, 30, true);
+			// //actually do the knocking
+			// setKnocked(caller, 30, true); //idk seas of salt are extra deep with this one
 		}
 	}
 }

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.as
@@ -168,6 +168,14 @@ void onTick(CBlob@ this)
 		int ammo = GetAmmo(this);
 		
 		CBlob@ t = getBlobByNetworkID(this.get_u16("target"));
+		CPlayer@ host = this.getDamageOwnerPlayer();
+		if (t !is null) {
+			CPlayer@ _target = t.getPlayer();
+			if (host !is null && _target is host) { //recognizes host and changes team
+				this.server_setTeamNum(_target.getTeamNum());
+				@t = null;
+			}
+		}
 		if (t is null || !isVisible(this, t) || ((t.getPosition() - this.getPosition()).LengthSquared() > 450.00f*450.00f)) //if blob doesn't exist or gone out of tracking range or LoS
 		{
 			this.set_u16("target", 0); //then reset targetting

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.cfg
@@ -73,6 +73,8 @@ $name                                      = sentry
 											 SecurityLinkable.as;
 											 CollidesOnlyWithLarger.as;
 											 OwnedByUPF.as;
+											 noncapturable.as;
+
 f32_health                                 = 14.0
 # looks & behaviour inside inventory
 $inventory_name                            = UPF Peacekeeper

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.as
@@ -129,6 +129,14 @@ void onTick(CBlob@ this)
 			if (index < 0) return;
 			
 			CBlob@ target = blobsInRadius[index];
+			CPlayer@ host = this.getDamageOwnerPlayer();
+			if (target !is null) {
+				CPlayer@ _target = target.getPlayer();
+				if (host !is null && _target is host) { //recognizes host and changes team
+					this.server_setTeamNum(_target.getTeamNum());
+					return;
+				}
+			}
 			Zap(this, target);	
 		}
 	}

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.cfg
@@ -82,6 +82,7 @@ $name                               = 	zapper
 										Zapper.as;
 										SecurityLinkable.as;
 										OwnedByUPF.as;
+										noncapturable.as;
 f32 health                          = 10.0
 # looks & behaviour inside inventory
 $inventory_name                     = Zapper

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/noncapturable.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/noncapturable.as
@@ -1,0 +1,3 @@
+void onInit(CBlob@ this) {
+	this.Tag("noncapturable");
+}

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/uncap_team.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/uncap_team.as
@@ -1,0 +1,37 @@
+#include "neutral_team_assigner.as"
+
+#ifndef __uncap_team
+#define __uncap_team
+
+void uncap_team(uint teamnum) {
+	if (!isServer()) return;
+
+	//non-players get converted to chicken faction
+	const uint chicken_team = 250;
+	const uint pure_neutral_team = 255;
+	CBlob@[] blobs;
+	getBlobsByTag("capturable", @blobs);
+	getBlobsByTag("noncapturable", @blobs);
+	getBlobsByTag("change team on fort capture", @blobs); //is it even needed? doors n stuff, maybe something else (but also collides with capturable)
+	for (int i = 0; i < blobs.length; ++i) {
+		if (blobs[i].getTeamNum() != teamnum) continue;
+		blobs[i].server_setTeamNum(blobs[i].hasTag("door") ? pure_neutral_team : chicken_team);
+	}
+
+	//players get neutralized
+	CBlob@[] players;
+	getBlobsByTag("player", @players);
+	for (int i = 0; i < players.length; ++i) {
+		if (players[i].getTeamNum() != teamnum) continue;
+		uint team = chicken_team; //turn them into chickens if all else fails
+		CPlayer @player = players[i].getPlayer();
+		if (player !is null)
+			team = reserve_team(player.getUsername().split('~')[0]);
+		else if (players[i].hasTag("sleeper") && players[i].get_string("sleeper_name") != "")
+			team = reserve_team(players[i].get_string("sleeper_name"));
+		players[i].server_setTeamNum(team);
+		if (player !is null) player.server_setTeamNum(team);
+	}
+}
+
+#endif

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/uncap_team.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/uncap_team.as
@@ -15,7 +15,7 @@ void uncap_team(uint teamnum) {
 	getBlobsByTag("change team on fort capture", @blobs); //is it even needed? doors n stuff, maybe something else (but also collides with capturable)
 	for (int i = 0; i < blobs.length; ++i) {
 		if (blobs[i].getTeamNum() != teamnum) continue;
-		blobs[i].server_setTeamNum(blobs[i].hasTag("door") ? pure_neutral_team : chicken_team);
+		blobs[i].server_setTeamNum(blobs[i].hasTag("noncapturable") ? chicken_team : pure_neutral_team);
 	}
 
 	//players get neutralized

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/uncap_team.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/uncap_team.as
@@ -2,20 +2,19 @@
 
 #ifndef __uncap_team
 #define __uncap_team
+const uint pure_neutral_team = 255;
 
-void uncap_team(uint teamnum) {
+void uncap_team(uint teamnum, uint target_team = pure_neutral_team) {
 	if (!isServer()) return;
 
 	//non-players get converted to chicken faction
-	const uint chicken_team = 250;
-	const uint pure_neutral_team = 255;
 	CBlob@[] blobs;
 	getBlobsByTag("capturable", @blobs);
 	getBlobsByTag("noncapturable", @blobs);
 	getBlobsByTag("change team on fort capture", @blobs); //is it even needed? doors n stuff, maybe something else (but also collides with capturable)
 	for (int i = 0; i < blobs.length; ++i) {
 		if (blobs[i].getTeamNum() != teamnum) continue;
-		blobs[i].server_setTeamNum(blobs[i].hasTag("noncapturable") ? chicken_team : pure_neutral_team);
+		blobs[i].server_setTeamNum(target_team);
 	}
 
 	//players get neutralized
@@ -23,7 +22,7 @@ void uncap_team(uint teamnum) {
 	getBlobsByTag("player", @players);
 	for (int i = 0; i < players.length; ++i) {
 		if (players[i].getTeamNum() != teamnum) continue;
-		uint team = chicken_team; //turn them into chickens if all else fails
+		uint team = target_team;
 		CPlayer @player = players[i].getPlayer();
 		if (player !is null)
 			team = reserve_team(player.getUsername().split('~')[0]);

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/ArmoredBomber/ArmoredBomber.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/ArmoredBomber/ArmoredBomber.cfg
@@ -13,6 +13,7 @@ $sprite_factory                            = generic_sprite
 											 ArmoredBomber.as;
 											 BomberCommon.as;
 											 HealthBar.as;
+											 VehicleConvert.as;
 $sprite_texture                            = ArmoredBomber.png
 s32_sprite_frame_width                     = 48
 s32_sprite_frame_height                    = 16

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/ArmoredCar/AmoredCar.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/ArmoredCar/AmoredCar.cfg
@@ -5,6 +5,7 @@ $sprite_factory                            = generic_sprite
 											 Stone.as;
 											 ArmoredCar.as;
 											 HealthBar.as;
+											 VehicleConvert.as;
 $sprite_texture                            = ArmoredCar.png
 s32_sprite_frame_width                     = 48
 s32_sprite_frame_height                    = 32
@@ -87,6 +88,7 @@ $name                                      = armoredcar
 										Metal.as;
 										MetalHit.as;  
 										VehicleAttachment.as;
+										VehicleConvert.as;
 										RunOverPeople.as;
 										DestructionAnimation.as;
 f32 health                                 = 40.0

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Bomber/Bomber.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Bomber/Bomber.cfg
@@ -13,6 +13,7 @@ $sprite_factory                            = generic_sprite
 											 Bomber.as;
 											 BomberCommon.as;
 											 HealthBar.as;
+											 VehicleConvert.as;
 $sprite_texture                            = Balloon.png
 s32_sprite_frame_width                     = 48
 s32_sprite_frame_height                    = 16

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Car/Car.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Car/Car.cfg
@@ -5,6 +5,7 @@ $sprite_factory                            = generic_sprite
 											 Stone.as;
 											 Car.as;
 											 HealthBar.as;
+											 VehicleConvert.as;
 $sprite_texture                            = Car.png
 s32_sprite_frame_width                     = 44
 s32_sprite_frame_height                    = 24
@@ -93,6 +94,7 @@ $name                                      = car
 										Metal.as;
 										MetalHit.as;  
 										VehicleAttachment.as;
+										VehicleConvert.as;
 										DestructionAnimation.as;
 f32 health                                 = 15.0
 # looks & behaviour inside inventory

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Dropship/Dropship.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Dropship/Dropship.cfg
@@ -12,6 +12,7 @@ $sprite_factory                            = generic_sprite
 											 FireAnim.as;
 											 Dropship.as;
 											 HealthBar.as;
+											 VehicleConvert.as;
 $sprite_texture                            = Dropship.png
 s32_sprite_frame_width                     = 80
 s32_sprite_frame_height                    = 32

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Helichopper/Helichopper.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Helichopper/Helichopper.cfg
@@ -5,6 +5,7 @@ $sprite_factory                                   = generic_sprite
                                                     SeatsGUI.as;
                                                     HealthBar.as;
 													Metal.as;
+													VehicleConvert.as;
 $sprite_texture                                   = Helichopper.png
 s32_sprite_frame_width                            = 80
 s32_sprite_frame_height                           = 40
@@ -73,6 +74,7 @@ $name                                             = helichopper
 													MetalHit.as;
 													Metal.as;
 													Seats.as;
+													VehicleConvert.as;
 f32 health                                        = 60.00f
 $inventory_name                                   = Helichopper
 $inventory_icon                                   = -

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/JetFighter/JetFighter.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/JetFighter/JetFighter.cfg
@@ -4,6 +4,7 @@ $sprite_factory                                   = generic_sprite
 													Metal.as;
 													HealthBar.as;
 													JetFighter.as;
+													VehicleConvert.as;
 $sprite_texture                                   = JetFighter.png
 s32_sprite_frame_width                            = 80
 s32_sprite_frame_height                           = 32

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/SteamTank/SteamTank.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/SteamTank/SteamTank.cfg
@@ -6,6 +6,7 @@ $sprite_factory                            = generic_sprite
 											 #SteamTankAnim.as;	
 											 SteamTank.as;
 											 HealthBar.as;
+											 VehicleConvert.as;
 $sprite_texture                            = SteamTank.png
 s32_sprite_frame_width                     = 44
 s32_sprite_frame_height                    = 24
@@ -103,6 +104,7 @@ $name                                      = steamtank
 										Metal.as;
 										MetalHit.as;
 										VehicleAttachment.as;
+										VehicleConvert.as;
 										RunOverPeople.as;
 										DestructionAnimation.as;
 f32 health                                 = 70.0

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Triplane/Triplane.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Triplane/Triplane.cfg
@@ -5,6 +5,7 @@ $sprite_factory                                   = generic_sprite
 													HealthBar.as;
 													FireAnim.as;
 													Triplane.as;
+													VehicleConvert.as;
 $sprite_texture                                   = Triplane.png
 s32_sprite_frame_width                            = 80
 s32_sprite_frame_height                           = 32


### PR DESCRIPTION
Mostly related to capping and contesting
1. Neutrals now keep their team between respawns (neutral team is unique for each player and is determined the moment said player spawns as neutral).
2. Neutral vehicles can't be instantly capped by sitting into any seat anymore, that only happens if you sit in driver or flyer seat.
3. Chicken vehicles are no longer considered neutral (you have to cap them first in order to be able to enter them)
4. Contesting is back, ppl now can defend their stuff from being captured; in order to make progress at capping stuff you have to have number advantage over defenders, and to actually cap (last step) you have to wipe all the defenders. Applies to both structures and vehicles.
5. Ppl can't respawn at contested bases anymore unless defenders have same numbers or number advantage. Travelling to contested bases strips invlunerability, there's also commented out (ppl were extra toxic about that, idk but I think it's still good to stun ppl for short time in these cases) chunk that stuns ppl that travel to bases losing contest.
6. Whenever faction is capped or destroyed it's stuff is uncapped (players change to their neutral teams, other stuff changes to pure neutral).
7. Chicken sentries (peacekeeper and zapper) won't attack their host even if it has different team; if it has different team sentry will change team.

Aside from this there are some minor fixes (faction base checks not including citadels, shorter respawns as bonus for good upkeep actually triggering on bad upkeep, maybe something else).