### PR TITLE
Renaming faction bases + small fixes

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Archer/ArcherAnim.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Archer/ArcherAnim.as
@@ -48,14 +48,16 @@ void LoadSprites(CSprite@ this)
 	}
 	else
 	{
-		switch(armour)
+		switch (armour)
 		{
-			case PLAYER_ARMOUR_STANDARD:
-				ensureCorrectRunnerTexture(this, "archer", "Archer");
+		case PLAYER_ARMOUR_STANDARD:
+			ensureCorrectRunnerTexture(this, "archer", "Archer");
 			break;
-
-			case PLAYER_ARMOUR_CAPE:
-				ensureCorrectRunnerTexture(this, "archer_cape", "ArcherCape");
+		case PLAYER_ARMOUR_CAPE:
+			ensureCorrectRunnerTexture(this, "archer_cape", "ArcherCape");
+			break;
+		case PLAYER_ARMOUR_GOLD:
+			ensureCorrectRunnerTexture(this, "archer_gold",  "ArcherGold");
 			break;
 		}
 	}

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderAnim.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderAnim.as
@@ -46,14 +46,16 @@ void LoadSprites(CSprite@ this)
 		}
 	}
 
-	switch(armour)
+	switch (armour)
 	{
-		case PLAYER_ARMOUR_STANDARD:
-			ensureCorrectRunnerTexture(this, "builder", "Builder");
+	case PLAYER_ARMOUR_STANDARD:
+		ensureCorrectRunnerTexture(this, "builder", "Builder");
 		break;
-		
-		case PLAYER_ARMOUR_CAPE:
-			ensureCorrectRunnerTexture(this, "builder_cape", "BuilderCape");
+	case PLAYER_ARMOUR_CAPE:
+		ensureCorrectRunnerTexture(this, "builder_cape", "BuilderCape");
+		break;
+	case PLAYER_ARMOUR_GOLD:
+		ensureCorrectRunnerTexture(this, "builder_gold", "BuilderGold");
 		break;
 	}
 

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
@@ -146,7 +146,7 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 						if(e.getTeamNum() != this.getTeamNum() && distance <= 256 && distance >= 8)
 						{
 							fail = true;
-							if (this.isMyPlayer()) client_AddToChat("There is an enemy faction base near! pos: " + pos.x + ", "+pos.y+", team: "+e.getTeamNum()+" distance: "+ distance, SColor(0xff444444));
+							if (this.isMyPlayer()) client_AddToChat("There is an enemy faction base near!", SColor(0xff444444));
 							break;
 						}
 					}

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
@@ -143,10 +143,10 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 						CBlob@ e = blobs[i];
 						Vec2f vector = e.getPosition() - pos;
 						f32 distance = vector.getLength();
-						if(e.getTeamNum() != this.getTeamNum() && distance <= 256)
+						if(e.getTeamNum() != this.getTeamNum() && distance <= 256 && distance >= 8)
 						{
 							fail = true;
-							if (this.isMyPlayer()) client_AddToChat("There is an enemy faction base near!", SColor(0xff444444));
+							if (this.isMyPlayer()) client_AddToChat("There is an enemy faction base near! pos: " + pos.x + ", "+pos.y+", team: "+e.getTeamNum()+" distance: "+ distance, SColor(0xff444444));
 							break;
 						}
 					}

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Knight/KnightAnim.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Knight/KnightAnim.as
@@ -70,16 +70,18 @@ void LoadSprites(CSprite@ this)
         }
 	}
 
-    switch(armour)
-    {
-        case PLAYER_ARMOUR_STANDARD:
-            ensureCorrectRunnerTexture(this, "knight", "Knight");
-        break;
-
-        case PLAYER_ARMOUR_CAPE:
-            ensureCorrectRunnerTexture(this, "knight_cape", "KnightCape");
-        break;
-    }
+    switch (armour)
+	{
+	case PLAYER_ARMOUR_STANDARD:
+		ensureCorrectRunnerTexture(this, "knight", "Knight");
+		break;
+	case PLAYER_ARMOUR_CAPE:
+		ensureCorrectRunnerTexture(this, "knight_cape", "KnightCape");
+		break;
+	case PLAYER_ARMOUR_GOLD:
+		ensureCorrectRunnerTexture(this, "knight_gold", "KnightGold");
+		break;
+	}
 }
 
 void onTick(CSprite@ this)

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Camp/Camp.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Camp/Camp.as
@@ -127,7 +127,13 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			
 			if (isServer())
 			{
-				CBlob@ newBlob = server_CreateBlob("fortress", team, pos);
+				CBlob@ newBlob = server_CreateBlobNoInit("fortress");
+				newBlob.server_setTeamNum(team);
+				newBlob.setPosition(pos);
+				newBlob.set_string("base_name", this.get_string("base_name"));
+				newBlob.Init();
+
+
 				this.MoveInventoryTo(newBlob);
 				this.server_Die();
 			}

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Fortress/Fortress.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Fortress/Fortress.as
@@ -128,7 +128,12 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			
 			if (isServer())
 			{
-				CBlob@ newBlob = server_CreateBlob("citadel", team, pos);
+				CBlob@ newBlob = server_CreateBlobNoInit("citadel");
+				newBlob.server_setTeamNum(team);
+				newBlob.setPosition(pos);
+				newBlob.set_string("base_name", this.get_string("base_name"));
+				newBlob.Init();
+
 				this.MoveInventoryTo(newBlob);
 				this.server_Die();
 			}


### PR DESCRIPTION
Now faction members can give names to faction bases by using paper with text (!write). Renaming a base in such way changes it's inventory name and "sticks" to base (upgrading it will keep it's name) (naming a camp "Bastion" will result in new name 'Camp "Bastion"', upgrading it will create 'Fortress "Bastion"'). If named base is captured or destroyed, it triggers global chat message about it (same message that triggers when last faction base is captured/destroyed). Chat messages about faction bases being capped/destroyed and about red alert now mention affected base.
Fixes: clientside check for nearby bases when building camp didn't work properly; builder, archer and knight didn't change textures on player info change if host player had golden tools.