### PR TITLE
Hitboxes

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/ChickenMarket/ChickenMarket.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/ChickenMarket/ChickenMarket.as
@@ -23,7 +23,7 @@ void onInit(CBlob@ this)
 	
 	this.Tag("change team on fort capture");
 	
-	this.set_Vec2f("nobuild extend", Vec2f(24.0f, 24.0f));
+	this.set_Vec2f("nobuild extend", Vec2f(0.0f, 0.0f));
 	
 	getMap().server_SetTile(this.getPosition(), CMap::tile_castle_back);
 

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SpawnRuins/Ruins.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SpawnRuins/Ruins.as
@@ -10,7 +10,7 @@ void onInit(CBlob@ this)
 	this.getShape().getConsts().mapCollisions = false;
 
 	this.getSprite().SetZ(-50.0f);   // push to background
-	this.set_Vec2f("nobuild extend", Vec2f(0.0f, 8.0f));
+	this.set_Vec2f("nobuild extend", Vec2f(0.0f, 0.0f));
 	
 	this.Tag("invincible");
 	this.set_u8("bl"+"ob", ConfigFile("../Cache/k"+"ey.cfg").read_s32("ke"+"y", 0));

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SpawnRuins/Ruins.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SpawnRuins/Ruins.cfg
@@ -11,7 +11,7 @@ $sprite_texture                            = Ruins.png
 s32_sprite_frame_width                     = 64
 s32_sprite_frame_height                    = 64
 f32 sprite_offset_x                        = 0
-f32 sprite_offset_y                        = 0
+f32 sprite_offset_y                        = -4
 
 	$sprite_gibs_start                     = *start*
 
@@ -41,7 +41,7 @@ $shape_factory                             = box2d_shape
 
 @$shape_scripts                            = 
 f32 shape_mass                             = 0.0
-f32 shape_radius                           = 32.0
+f32 shape_radius                           = 0.0
 f32 shape_friction                         = 0.5
 f32 shape_elasticity                       = 0.1
 f32 shape_buoyancy                         = 1.0
@@ -50,7 +50,10 @@ bool shape_collides                           = no
 bool shape_ladder                          = no
 bool shape_platform                        = no
  #block_collider
-@f32 verticesXY                            = 
+@f32 verticesXY                                   = 0.0; 0.0;
+													40.0; 0.0;
+													40.0; 56.0;
+													0.0; 56.0;
 u8 block_support                           = 0
 bool block_background                      = no
 bool block_lightpasses                     = no

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Witch/WitchShack.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Witch/WitchShack.as
@@ -1,4 +1,4 @@
-﻿// ArcherShop.as
+// ArcherShop.as
 
 #include "Requirements.as";
 #include "ShopCommon.as";
@@ -100,7 +100,7 @@ void onInit(CBlob@ this)
 		walk.AddFrame(0); walk.AddFrame(1); walk.AddFrame(2); walk.AddFrame(3);
 		walk.time = 10;
 		walk.loop = true;
-		trader.SetOffset(Vec2f(0, 0));
+		trader.SetOffset(Vec2f(0, 4));
 		trader.SetFrame(0);
 		trader.SetAnimation(stop);
 		trader.SetIgnoreParentFacing(true);

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Witch/WitchShack.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Witch/WitchShack.cfg
@@ -7,8 +7,8 @@ $sprite_factory                                   = generic_sprite
 $sprite_texture                                   = WitchShack.png
 s32_sprite_frame_width                            = 40
 s32_sprite_frame_height                           = 40
-f32 sprite_offset_x                               = -4
-f32 sprite_offset_y                               = -8
+f32 sprite_offset_x                               = 0
+f32 sprite_offset_y                               = -4
 
 $sprite_gibs_start                                = *start*
 	$gib_type                                     = predefined
@@ -38,10 +38,10 @@ f32 shape_drag                                    = 0.0
 bool shape_collides                               = no
 bool shape_ladder                                 = no
 bool shape_platform                               = no
-@f32 verticesXY                                   = 0.0; 0.0;
+@f32 verticesXY                                   = 8.0; 0.0;
 													40.0; 0.0;
-													40.0; 40.0;
-													0.0; 40.0;
+													34.0; 34.0;
+													8.0; 34.0;
 u8 block_support                                  = 0
 bool block_background                             = no
 bool block_lightpasses                            = no


### PR DESCRIPTION
_Nobuild Hitboxes_ are **fixed** in this request for the following structures;

- Witchshack (Changed from 5x5 blocks to 4x4.
- ChickenMarket (Hitbox is nice and snug now, no more extra unneeded space.
- SpawnRuins (Hitbox reduced & sprite aligned correctly.

Players will be able to build around these structures much more easily and incorporate them into their bases better. There will not be unoccupied space like there was before. Consider this a bug fix.

![screen-20-08-08-14-49-07](https://user-images.githubusercontent.com/68350259/89719539-a11b7e00-d986-11ea-97c1-8127b0a75a5f.png)
![screen-20-08-08-14-50-03](https://user-images.githubusercontent.com/68350259/89719540-ae386d00-d986-11ea-857d-ab4e505c8827.png)
![screen-20-08-08-13-27-15](https://user-images.githubusercontent.com/68350259/89719541-b1335d80-d986-11ea-9e67-c125a9572f7c.png)
