### PR TITLE
Capturable automat

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Automat/Automat.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Automat/Automat.cfg
@@ -3,6 +3,7 @@ $sprite_factory                                   = generic_sprite
 @$sprite_scripts                                  = Automat.as;
 													HealthBar.as;
 													Stone.as;
+													VehicleConvert.as;
 													
 $sprite_texture                                   = Automat.png
 s32_sprite_frame_width                            = 16
@@ -70,6 +71,7 @@ $name                                             = automat
 													Metal.as;
 													MetalHit.as;
 													NoPlayerCollision.as;
+													VehicleConvert.as;
 													RunnerDeath.as; # this checks for "dead" so leave it last
 f32 health                                        = 10.0
 # looks & behaviour inside inventory

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SpawnRuins/Ruins.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SpawnRuins/Ruins.cfg
@@ -11,7 +11,7 @@ $sprite_texture                            = Ruins.png
 s32_sprite_frame_width                     = 64
 s32_sprite_frame_height                    = 64
 f32 sprite_offset_x                        = 0
-f32 sprite_offset_y                        = 0
+f32 sprite_offset_y                        = -4
 
 	$sprite_gibs_start                     = *start*
 
@@ -41,7 +41,7 @@ $shape_factory                             = box2d_shape
 
 @$shape_scripts                            = 
 f32 shape_mass                             = 0.0
-f32 shape_radius                           = 32.0
+f32 shape_radius                           = 0.0
 f32 shape_friction                         = 0.5
 f32 shape_elasticity                       = 0.1
 f32 shape_buoyancy                         = 1.0
@@ -50,7 +50,10 @@ bool shape_collides                           = no
 bool shape_ladder                          = no
 bool shape_platform                        = no
  #block_collider
-@f32 verticesXY                            = 
+@f32 verticesXY                                   = 0.0; 0.0;
+													40.0; 0.0;
+													40.0; 56.0;
+													0.0; 56.0;
 u8 block_support                           = 0
 bool block_background                      = no
 bool block_lightpasses                     = no


### PR DESCRIPTION
VehicleConvert.as script added to Automat.cfg to allow for players to capture the autonomous activator.
- Mainly requested since players could not use automats gained from mystery boxes (this will fix that)
- Players will be able to steal other's automats if they are left unattended. Will be good for gameplay.
![screen-20-08-08-23-24-58](https://user-images.githubusercontent.com/68350259/89725822-2e83c000-d9d1-11ea-925b-5970dffb7ac3.png)
