### PR TITLE
Acid Rapid Decay bug

### DIFF
--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/AcidGas/AcidGas.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/AcidGas/AcidGas.as
@@ -51,7 +51,7 @@ void onTick(CBlob@ this)
 			
 			TileType type = map.getTile(bpos).type;
 			
-			if (!isTileGlass(type) && !isTileBGlass(type) && type != CMap::tile_empty)
+			if (!isTileGlass(type) && !isTileBGlass(type) && type != CMap::tile_empty && type != CMap::tile_ground_back)
 			{
 				if (server)
 				{


### PR DESCRIPTION
Acid rapidly decays when touching dirt background, because it doesn't ignore it. Now it's fixed.