### PR TITLE
Engineer Had Tag Neutral

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Engineer/EngineerLogic.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Engineer/EngineerLogic.as
@@ -2,7 +2,6 @@
 
 void onInit(CBlob@ this)
 {
-	this.Tag("neutral");
 	this.Tag("human");
 	
 	this.set_f32("mining_multiplier", 0.75f);


### PR DESCRIPTION
Removed this.Tag("neutral");
Caused factions to be able to change class to bandit through engineer + made them unable to break irondoors and stuff.