### PR TITLE
Reduced Some Prices of bombshop

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/BombShop/BombShop.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/BombShop/BombShop.as
@@ -118,7 +118,7 @@ void onInit(CBlob@ this)
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Cluster Bomb (1)", "$icon_clusterbomb$", "mat_clusterbomb-1", "A cluster bomb that splits into smaller bomblets upon detonation.");
-		AddRequirement(s.requirements, "coin", "", "Coins", 500);
+		AddRequirement(s.requirements, "coin", "", "Coins", 250);
 		AddRequirement(s.requirements, "blob", "mat_methane", "Methane", 25);
 		AddRequirement(s.requirements, "blob", "mat_sulphur", "Sulphur", 25);
 
@@ -217,7 +217,6 @@ void onInit(CBlob@ this)
 	{
 		ShopItem@ s = addShopItem(this, "Fragmentation Grenade (1)", "$icon_fraggrenade$", "mat_fraggrenade-1", "A small hand grenade. Especially useful against infantry.");
 		AddRequirement(s.requirements, "coin", "", "Coins", 75);
-		AddRequirement(s.requirements, "blob", "mat_sulphur", "Sulphur", 25);
 
 		s.spawnNothing = true;
 	}


### PR DESCRIPTION
Clusterbomb costed 500 coins which was way too much, didn't change dirty bomb since it's worth price.
Fragmentation Grenade would be cool if they were used more. Didn't make sense for them to cost as much as a dynamite when even smallbomb is cheaper and 5x stronger.