### PR TITLE
Grain overhaul

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/Grain.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/Grain.cfg
@@ -70,7 +70,8 @@ $name                                  = grain
 										 Eatable.as;
 										 Timeout.as;
 										 NoPlayerCollision.as;
-f32 health                             = 1.0
+										 MarkForPickup_Builder;
+f32 health                             = 2.0
 # looks & behaviour inside inventory
 $inventory_name                        = Grain
 $inventory_icon                        = -
@@ -79,4 +80,4 @@ u8 inventory_icon_frame_width          = 0
 u8 inventory_icon_frame_height         = 0
 u8 inventory_used_width                = 1
 u8 inventory_used_height               = 1
-u8 inventory_max_stacks                = 0
+u8 inventory_max_stacks                = 5

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/GrainPlant.cfg
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/GrainPlant.cfg
@@ -1,0 +1,108 @@
+# Grain Plant config file
+# $ string
+# @ array
+
+# sprite
+
+$sprite_factory                        = generic_sprite
+
+@$sprite_scripts                       = PlantAnim.as;
+										 FireAnim.as;
+
+$sprite_texture                        = Grain.png
+s32_sprite_frame_width                 = 16
+s32_sprite_frame_height                = 16
+f32 sprite_offset_x                    = 0
+f32 sprite_offset_y                    = -4
+
+	$sprite_gibs_start                 = *start*
+	
+	$gib_type                          = predefined
+	$gib_style                         = plant
+	u8_gib_count                       = 3
+	@u8_gib_frame                      = 4; 5; 6; 7;
+	f32 velocity                       = 10.0
+	f32 offset_x                       = 4.0
+	f32 offset_y                       = 0.0
+	
+	$gib_type                          = predefined
+	$gib_style                         = plant
+	u8_gib_count                       = 2
+	@u8_gib_frame                      = 4; 5; 6; 7;
+	f32 velocity                       = 10.0
+	f32 offset_x                       = -4.0
+	f32 offset_y                       = 0.0
+	
+	$gib_type                          = predefined
+	$gib_style                         = plant
+	u8_gib_count                       = 2
+	@u8_gib_frame                      = 4; 5; 6; 7;
+	f32 velocity                       = 10.0
+	f32 offset_x                       = 0.0
+	f32 offset_y                       = 0.0
+	
+	$sprite_gibs_end                   = *end*
+									
+  $sprite_animation_start              = *start*
+  
+  # growth
+  $sprite_animation_growth_name        = growth
+  u16 sprite_animation_growth_time     = 0
+  u8_sprite_animation_growth_loop      = 0
+  @u16 sprite_animation_growth_frames  = 1; 2; 3; 4; 5; 6;
+  
+  # default
+  $sprite_animation_default_name       = grown
+  u16 sprite_animation_default_time    = 0
+  u8_sprite_animation_default_loop     = 0
+  @u16 sprite_animation_default_frames = 6; 6; 7; 7;
+  
+  $sprite_animation_end                = *end*
+  
+# shape
+
+$shape_factory                         = box2d_shape
+
+@$shape_scripts                        =
+f32 shape_mass                         = 5.0
+f32 shape_radius                       = 3.5
+f32 shape_friction                     = 0.5
+f32 shape_elasticity                   = 0.0
+f32 shape_buoyancy                     = 0.8
+f32 shape_drag                         = 0.1
+bool shape_collides                       = no
+bool shape_ladder                      = no
+bool shape_platform                    = no
+ #block_collider
+@f32 verticesXY                        =
+u8 block_support                       = 0
+bool block_background                  = no
+bool block_lightpasses                 = no
+bool block_snaptogrid                  = no
+
+$movement_factory                      = 
+$brain_factory                         =
+$attachment_factory                    = 					  
+$inventory_factory                     = 		  
+
+# general
+
+$name                                  = grain_plant
+@$scripts                              = 
+										PlantGrowth.as;
+										GrainPlantLogic.as;
+										GrainPlantStuff.as;
+										IsFlammable.as;
+										AlignToTiles.as;
+										UnsetTeam.as;
+										PlantHitEffects.as;
+f32 health                             = 1.0
+# looks & behaviour inside inventory
+$inventory_name                        = Grain Plant
+$inventory_icon                        = -
+u8 inventory_icon_frame                = 0
+u8 inventory_icon_frame_width          = 0
+u8 inventory_icon_frame_height         = 0
+u8 inventory_used_width                = 2
+u8 inventory_used_height               = 2
+u8 inventory_max_stacks                = 0

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/GrainPlantStuff.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/GrainPlantStuff.as
@@ -10,15 +10,11 @@ void onDie(CBlob@ this)
 	{
 		if (this.hasTag("has grain"))
 		{			
-		    for (int i = 1; i <= 1; i++)
+			CBlob@ grain = server_CreateBlob("grain", this.getTeamNum(), this.getPosition() + Vec2f(0, -12));
+			if (grain !is null)
 			{
-				CBlob@ grain = server_CreateBlob("grain", this.getTeamNum(), this.getPosition() + Vec2f(0, -12));
-				if (grain !is null)
-			    {
-				    server_MakeSeed(this.getPosition(), "grain_plant", 300, 1, 4);
-				}
+				server_MakeSeed(this.getPosition(), "grain_plant", 300, 1, 4);
 			}
 		}
 	}
 }
-

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/GrainPlantStuff.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/GrainPlantStuff.as
@@ -1,0 +1,24 @@
+#include "MakeSeed.as";
+bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
+{
+	return false;
+}
+
+void onDie(CBlob@ this)
+{
+	if (getNet().isServer())
+	{
+		if (this.hasTag("has grain"))
+		{			
+		    for (int i = 1; i <= 1; i++)
+			{
+				CBlob@ grain = server_CreateBlob("grain", this.getTeamNum(), this.getPosition() + Vec2f(0, -12));
+				if (grain !is null)
+			    {
+				    server_MakeSeed(this.getPosition(), "grain_plant", 300, 1, 4);
+				}
+			}
+		}
+	}
+}
+

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/GrainPlantStuff.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/Grain/GrainPlantStuff.as
@@ -6,7 +6,7 @@ bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 
 void onDie(CBlob@ this)
 {
-	if (getNet().isServer())
+	if (isServer())
 	{
 		if (this.hasTag("has grain"))
 		{			

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Nature/MakeSeed.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Nature/MakeSeed.as
@@ -69,6 +69,26 @@ CBlob@ server_MakeSeed(Vec2f atpos, string blobname)
 	return server_MakeSeed(atpos, blobname, 100, 0, 4);
 }
 
+void server_MakeSeedsFor(CBlob@ this, string blobname, u8 amount)
+{
+    if (this is null) return;
+
+    for (u8 i = 0; i < amount; i++)
+    {
+        CBlob@ blob = server_MakeSeed(this.getPosition(), blobname);
+
+        if (blob is null) continue;
+               
+        if (!blob.canBePutInInventory(this))
+        {
+            this.server_Pickup(blob);
+        }
+        else if (this.getInventory() !is null && !this.getInventory().isFull())
+        {
+            this.server_PutInInventory(blob);
+        }
+    }
+}
 
 ShopItem@ addSeedItem(CBlob@ this, const string &in seedName,
                       const string &in  description, u16 timeToMakeSecs, const u16 quantityLimit, CBitStream@ requirements = null)

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Vodka/Vodka.cfg
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Vodka/Vodka.cfg
@@ -61,11 +61,11 @@ $name                                             = vodka
 													NoPlayerCollision.as;
 													ForceFeedable.as;
 f32 health                                        = 1.0
-$inventory_name                                   = Vodka!
+$inventory_name                                   = Vodka
 $inventory_icon                                   = -
 u8 inventory_icon_frame                           = 0
 u8 inventory_icon_frame_width                     = 8
 u8 inventory_icon_frame_height                    = 16
 u8 inventory_used_width                           = 1
 u8 inventory_used_height                          = 1
-u8 inventory_max_stacks                           = 1
+u8 inventory_max_stacks                           = 4

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/DrugLab/DrugLab.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/DrugLab/DrugLab.as
@@ -62,18 +62,22 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
-	CBitStream params;
+	if (this.isOverlapping(caller))
+	{
+		CBitStream params;
 
-	{
-		CButton@ button = caller.CreateGenericButton(11, Vec2f(-4, -2), this, this.getCommandID("lab_react"), "React", params);
-		button.SetEnabled(getGameTime() >= this.get_u32("next_react"));
-	}
+		{
+			CButton@ button = caller.CreateGenericButton(11, Vec2f(-4, -2), this, this.getCommandID("lab_react"), "React", params);
+			button.SetEnabled(getGameTime() >= this.get_u32("next_react"));
+		}
 	
-	{
+		{
 		CButton@ button = caller.CreateGenericButton(11, Vec2f(-4, 6.5f), this, this.getCommandID("lab_add_heat"), "Increase Heat", params);
 		button.deleteAfterClick = false;
+		}
 	}
 }
+
 
 void React(CBlob@ this)
 {
@@ -115,6 +119,7 @@ void React(CBlob@ this)
 			CBlob@ protopopovBulb_blob = inv.getItem("protopopovbulb");
 			CBlob@ vodka_blob = inv.getItem("vodka");
 			CBlob@ fiks_blob = inv.getItem("fiks");
+			CBlob@ grain_blob = inv.getItem("grain");
 
 			bool hasOil = oil_blob !is null;
 			bool hasMethane = methane_blob !is null;
@@ -131,6 +136,34 @@ void React(CBlob@ this)
 			bool hasProtopopovBulb = protopopovBulb_blob !is null;
 			bool hasVodka = vodka_blob !is null;
 			bool hasFiks = fiks_blob !is null;
+			bool hasGrain = grain_blob !is null;
+			
+			if (meat_count > 0 && meat_blob !is null)
+			{
+				f32 explodium_amount = meat_blob.get_f32("explodium_amount");
+				
+				if (isServer())
+				{
+					Material::createFor(this, "mat_explodium", Maths::Ceil(explodium_amount));
+				}
+				
+				meat_blob.set_f32("explodium_amount", 0.00f);
+				
+				ShakeScreen(60.0f, 30, this.getPosition());
+				this.getSprite().PlaySound("DrugLab_Create_Gas.ogg", 1.00f, 1.00f);
+			}
+			
+			if (heat > 1000 && hasGrain)
+			{
+				if (isServer())
+				{
+					grain_blob.server_Die();
+					Material::createFor(this, "vodka", 1);
+				}
+				
+				ShakeScreen(30.0f, 15, this.getPosition());
+				this.getSprite().PlaySound("DrugLab_Create_Acidic.ogg", 1.00f, 1.00f);
+			}
 			
 			if (heat > 500 && hasFiks)
 			{

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Treecapitator/Treecapitator.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Treecapitator/Treecapitator.as
@@ -51,13 +51,20 @@ void onTick(CBlob@ this)
 						}
 					}
 				}
-				else if (bname == "log" || bname == "pumpkin")
+				else if (bname == "log" || bname == "pumpkin" || bname == "grain" )
 				{
 					this.server_PutInInventory(b);
 				}
 				else if (bname == "pumpkin_plant")
 				{
 					if (b.hasTag("has pumpkin"))
+					{
+						this.server_Hit(b, b.getPosition(), Vec2f(0, 0), 1.00f, Hitters::saw);
+					}
+				}
+				else if (bname == "grain_plant")
+				{
+					if (b.hasTag("has grain"))
 					{
 						this.server_Hit(b, b.getPosition(), Vec2f(0, 0), 1.00f, Hitters::saw);
 					}

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Merchant/Merchant.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Merchant/Merchant.as
@@ -12,6 +12,8 @@ Random traderRandom(Time());
 
 void onInit(CBlob@ this)
 {
+	Random@ rand = Random(this.getNetworkID());
+
 	this.Tag("upkeep building");
 	this.set_u8("upkeep cap increase", 0);
 	this.set_u8("upkeep cost", 10);
@@ -85,8 +87,6 @@ void onInit(CBlob@ this)
 		s.spawnNothing = true;
 	}
 	
-	
-	
 	{
 		ShopItem@ s = addShopItem(this, "Sell Gold Ingot (1)", "$COIN$", "coin-100", "Sell 1 Gold Ingot for 100 coins.");
 		AddRequirement(s.requirements, "blob", "mat_goldingot", "Gold Ingot", 1);
@@ -121,18 +121,31 @@ void onInit(CBlob@ this)
 	}
 	
 	{
-		ShopItem@ s = addShopItem(this, "Sell Pumpkin (1)", "$COIN$", "coin-200", "Sell 1 pumpkin for 200 coins.");
+		u32 cost = getRandomCost(@rand, 100, 400);
+		ShopItem@ s = addShopItem(this, "Sell Pumpkin (1)", "$COIN$", "coin-" + cost, "Sell 1 pumpkin for " + cost + " coins.");
 		AddRequirement(s.requirements, "blob", "pumpkin", "Pumpkin", 1);
 		s.spawnNothing = true;
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Sell Oil Drum (50 l)", "$COIN$", "coin-300", "Sell 50 litres of oil for 300 coins.");
+		u32 cost = getRandomCost(@rand, 100, 500);
+		ShopItem@ s = addShopItem(this, "Sell Oil Drum (50 l)", "$COIN$", "coin-" + cost, "Sell 50 litres of oil for " + cost + " coins.");
 		AddRequirement(s.requirements, "blob", "mat_oil", "Oil Drum (50 l)", 50);
 		s.spawnNothing = true;
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Sell Scrub's Chow (1)", "$COIN$", "coin-200", "Sell 1 Scrub's Chow for 200 coins.");
+		u32 cost = getRandomCost(@rand, 50, 300);
+		ShopItem@ s = addShopItem(this, "Sell Scrub's Chow (1)", "$COIN$", "coin-" + cost, "Sell 1 Scrub's Chow for " + cost + " coins.");
 		AddRequirement(s.requirements, "blob", "foodcan", "Scrub's Chow", 1);
+		s.spawnNothing = true;
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Sell Grain (1)", "$COIN$", "coin-40", "Sell 1 grain for 40 coins.");
+		AddRequirement(s.requirements, "blob", "grain", "Grain", 1);
+		s.spawnNothing = true;
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Sell Grain (5)", "$COIN$", "coin-200", "Sell 5 grain for 200 coins.");
+		AddRequirement(s.requirements, "blob", "grain", "Grain", 5);
 		s.spawnNothing = true;
 	}
 	{
@@ -142,12 +155,12 @@ void onInit(CBlob@ this)
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Building for Dummies", "$artisancertificate$", "artisancertificate", "Simplified Builder manuscript for those dumb peasants.", true);
-		AddRequirement(s.requirements, "coin", "", "Coins", 500);
+		AddRequirement(s.requirements, "coin", "", "Coins", getRandomCost(@rand, 400, 800));
 		s.spawnNothing = true;
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Kitten", "$icon_kitten$", "kitten", "A cute little kitten! Take care of it!", false, true);
-		AddRequirement(s.requirements, "coin", "", "Coins", 200);
+		AddRequirement(s.requirements, "coin", "", "Coins", getRandomCost(@rand, 150, 500));
 		s.spawnNothing = true;
 	}
 	{
@@ -208,6 +221,11 @@ void onInit(CBlob@ this)
 		this.set_u32("next offset", traderRandom.NextRanged(16));
 
 	}
+}
+
+int getRandomCost(Random@ random, int min, int max, int rounding = 10)
+{
+	return Maths::Round(f32(min + random.NextRanged(max - min)) / rounding) * rounding;
 }
 
 void onTick(CBlob@ this)


### PR DESCRIPTION
**First Farming Overhaul**
This PR is meant to give grain & farming a bigger purpose within TC.

_Changes_
* Grain plant now drops 1 seed on death
* Grain plant support added to treecapacitator- allowing automatic farming
* Grain can be sold at the merchant for 40 coins for 1 grain, and 200 coins for 5 grain.
* Grain can now be stacked to 5 rather than 1
* New Vodka recipe in druglab (which uses grain)
* Vodka now stackable to 4 rather than 1.
* Druglab button range fixed (requested by vamjam)

More will be coming to farming, with upcoming plants & the new nursery building!