### PR TITLE
Upkeep re-haul

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
@@ -138,15 +138,16 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 				{
 					CBlob@[] blobs;
 					getBlobsByTag("faction_base", @blobs);
+					getBlobsByTag("upf_base", @blobs);
 					for (int i = 0; i < blobs.length; i++)
 					{
 						CBlob@ e = blobs[i];
 						Vec2f vector = e.getPosition() - pos;
 						f32 distance = vector.getLength();
-						if(e.getTeamNum() != this.getTeamNum() && distance <= 256 && distance >= 8)
+						if(/*e.getTeamNum() != this.getTeamNum() &&*/distance <= 256 && distance >= 8)
 						{
 							fail = true;
-							if (this.isMyPlayer()) client_AddToChat("There is an enemy faction base near!", SColor(0xff444444));
+							if (this.isMyPlayer()) client_AddToChat("There is a faction base too close!", SColor(0xff444444));
 							break;
 						}
 					}

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/CommonBuilderBlocks.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/CommonBuilderBlocks.as
@@ -312,7 +312,7 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks)
 	BuildBlock[] page_1;
 	blocks.push_back(page_1);
 	{
-		BuildBlock b(0, "quarters", "$quarters$", "Quarters\n" + descriptions[59] + "\n\nIncreases Upkeep cap by 10.");
+		BuildBlock b(0, "quarters", "$quarters$", "Quarters\n" + descriptions[59]);
 		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 50);
 		b.buildOnGround = true;
 		b.size.Set(40, 24);
@@ -327,7 +327,7 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks)
 		blocks[1].push_back(b);
 	}
 	{
-		BuildBlock b(0, "tinkertable", "$tinkertable$", "Mechanist's Workshop\nA place where you can construct various trinkets and advanced machinery. Repairs adjacent vehicles. \n\nCosts 5 Upkeep.");
+		BuildBlock b(0, "tinkertable", "$tinkertable$", "Mechanist's Workshop\nA place where you can construct various trinkets and advanced machinery. Repairs adjacent vehicles.");
 		AddRequirement(b.reqs, "blob", "mat_stone", "Stone", 70);
 		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 150);
 		// AddRequirement(b.reqs, "blob", "bp_mechanist", "Blueprint (Mechanist's Workshop)", 1);
@@ -336,7 +336,7 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks)
 		blocks[1].push_back(b);
 	}
 	{
-		BuildBlock b(0, "armory", "$armory$", "Armory\nA workshop where you can craft cheap equipment. Automatically stores nearby dropped weapons.\n\nCosts 5 Upkeep.");
+		BuildBlock b(0, "armory", "$armory$", "Armory\nA workshop where you can craft cheap equipment. Automatically stores nearby dropped weapons.");
 		AddRequirement(b.reqs, "blob", "mat_stone", "Stone", 100);
 		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 200);
 		// AddRequirement(b.reqs, "blob", "bp_mechanist", "Blueprint (Mechanist's Workshop)", 1);
@@ -345,7 +345,7 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks)
 		blocks[1].push_back(b);
 	}
 	{
-		BuildBlock b(0, "gunsmith", "$gunsmith$", "Gunsmith's Workshop\nA workshop for those who enjoy making holes. Slowly produces bullets.\n\nCosts 5 Upkeep.");
+		BuildBlock b(0, "gunsmith", "$gunsmith$", "Gunsmith's Workshop\nA workshop for those who enjoy making holes. Slowly produces bullets.");
 		AddRequirement(b.reqs, "blob", "mat_stone", "Stone", 150);
 		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 250);
 		// AddRequirement(b.reqs, "coin", "", "Coins", 75);
@@ -355,7 +355,7 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks)
 		blocks[1].push_back(b);
 	}
 	{
-		BuildBlock b(0, "bombshop", "$bombshop$", "Demolitionist's Workshop\nFor those with an explosive personality.\n\nCosts 5 Upkeep.");
+		BuildBlock b(0, "bombshop", "$bombshop$", "Demolitionist's Workshop\nFor those with an explosive personality.");
 		AddRequirement(b.reqs, "blob", "mat_stone", "Stone", 100);
 		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 250);
 		// AddRequirement(b.reqs, "coin", "", "Coins", 50);
@@ -402,7 +402,7 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks)
 		blocks[1].push_back(b);
 	}
 	{
-		BuildBlock b(0, "camp", "$icon_camp$", "Camp\nA basic faction base. Can be upgraded to gain\nspecial functions and more durability.\n\nIncreases Upkeep cap by 15.");
+		BuildBlock b(0, "camp", "$icon_camp$", "Camp\nA basic faction base. Can be upgraded to gain\nspecial functions and more durability.\n\nIncreases Upkeep cap by 1.");
 		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 500);
 		AddRequirement(b.reqs, "blob", "mat_stone", "Stone", 500);
 		AddRequirement(b.reqs, "coin", "", "Coins", 100);

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Chicken/Egg.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Chicken/Egg.as
@@ -1,8 +1,8 @@
 
 const int grow_time = 50 * getTicksASecond();
 
-const int MAX_CHICKENS_TO_HATCH = 5;
-const f32 CHICKEN_LIMIT_RADIUS = 120.0f;
+//const int MAX_CHICKENS_TO_HATCH = 5;
+//const f32 CHICKEN_LIMIT_RADIUS = 120.0f;
 
 void onInit(CBlob@ this)
 {
@@ -20,7 +20,7 @@ void onTick(CBlob@ this)
 {
 	if (isServer() && this.getTickSinceCreated() > grow_time)
 	{
-		int chickenCount = 0;
+		/*int chickenCount = 0;
 		CBlob@[] blobs;
 		getMap().getBlobsInRadius(this.getPosition(), CHICKEN_LIMIT_RADIUS, @blobs);
 		for (uint step = 0; step < blobs.length; ++step)
@@ -30,9 +30,9 @@ void onTick(CBlob@ this)
 			{
 				chickenCount++;
 			}
-		}
+		}*/
 
-		if (chickenCount < MAX_CHICKENS_TO_HATCH)
+		//if (chickenCount < MAX_CHICKENS_TO_HATCH)
 		{
 			this.SendCommand(this.getCommandID("hatch"));
 		}

--- a/TFlippy_TerritoryControl_Core_Dev/Addons/Sopranos/DefaultActorHUD.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Addons/Sopranos/DefaultActorHUD.as
@@ -110,7 +110,7 @@ void RenderUpkeepHUD(CBlob@ this)
 	
 	string msg = "";
 		
-	if (upkeep_ratio >= 0.75f) msg += "Your upkeep is too high, build\nmore Quarters, Camps or Fortresses!\n";
+	if (upkeep_ratio >= 0.75f) msg += "Your upkeep is too high, upgrade or\nbuild more Camps!";
 	else msg += "Your upkeep is balanced, therefore\nyour team will receive extra bonuses.";
 	
 	GUI::DrawText(msg, Vec2f(scWidth - 352, 62 + Maths::Sin(getGameTime() / 8.0f)), SColor(255, color_red, color_green, 0));

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Structs.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Structs.as
@@ -26,7 +26,7 @@
 	// // }
 // };
 
-const u16 UPKEEP_COST_PLAYER = 10;
+const u16 UPKEEP_COST_PLAYER = 1;
 
 const f32 UPKEEP_RATIO_BONUS_COIN_GAIN = 0.40f;
 const f32 UPKEEP_RATIO_BONUS_MINING = 0.45f;

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Teams.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Teams.as
@@ -179,7 +179,7 @@ void onTick(CRules@ this)
 				TeamData@ team = team_list[i];
 
 				team.upkeep = 0;
-				team.upkeep_cap = 30;
+				team.upkeep_cap = 1;
 				team.player_count = 0;
 				team.wealth = 0;
 				team.controlled_count = 0;
@@ -194,7 +194,7 @@ void onTick(CRules@ this)
 					u8 team = p.getTeamNum();
 					if (team >= maxTeams) continue;
 					
-					team_list[team].upkeep += 10 + (team_list[team].player_count * 5);
+					team_list[team].upkeep += 1 + (team_list[team].player_count * 5);
 					team_list[team].player_count++;
 					team_list[team].wealth += p.getCoins();
 				}
@@ -240,7 +240,7 @@ void onTick(CRules@ this)
 					u8 slaver_team = blob.get_u8("slaver_team");
 	
 					if (slaver_team > maxTeams) continue;
-					if (!blob.hasTag("dead")) team_list[slaver_team].upkeep += 50;
+					if (!blob.hasTag("dead")) team_list[slaver_team].upkeep += 1;
 				}
 			}
 				

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Boof/Boofed.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Boof/Boofed.as
@@ -35,7 +35,7 @@ void onTick(CBlob@ this)
 		RunnerMoveVars@ moveVars;
 		if (this.get("moveVars", @moveVars))
 		{
-			moveVars.walkFactor *= 0.60f;;
+			moveVars.walkFactor *= 0.60f - (true_level * 0.10f);
 			moveVars.jumpFactor *= 0.70f;
 		}	
 		
@@ -48,8 +48,17 @@ void onTick(CBlob@ this)
 			
 				ShakeScreen2(5.0f, 5.0f, this.getPosition());
 				if (getGameTime() % 5 == 0) SetScreenFlash(50, 10, 60, 50);
-			
-				if (XORRandom(500) == 0)
+				
+				if (XORRandom(300) == 0)
+				{
+					if (isClient()) 
+					{
+						this.getSprite().PlaySound("/cough" + XORRandom(5) + ".ogg", 0.6f, this.getSexNum() == 0 ? 1.0f : 2.0f);
+						if (this.isMyPlayer()) ShakeScreen(400, 5, this.getPosition());
+					}
+				}
+				
+				if (XORRandom(400) == 0)
 				{		
 					u8 emote = 0;
 							

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Boof/Boofed.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Boof/Boofed.as
@@ -51,11 +51,8 @@ void onTick(CBlob@ this)
 				
 				if (XORRandom(300) == 0)
 				{
-					if (isClient()) 
-					{
-						this.getSprite().PlaySound("/cough" + XORRandom(5) + ".ogg", 0.6f, this.getSexNum() == 0 ? 1.0f : 2.0f);
-						if (this.isMyPlayer()) ShakeScreen(400, 5, this.getPosition());
-					}
+					this.getSprite().PlaySound("/cough" + XORRandom(5) + ".ogg", 0.6f, this.getSexNum() == 0 ? 1.0f : 2.0f);
+					if (this.isMyPlayer()) ShakeScreen(400, 5, this.getPosition());
 				}
 				
 				if (XORRandom(400) == 0)

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/PatreonShop/PatreonShop.as
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/PatreonShop/PatreonShop.as
@@ -20,9 +20,9 @@ void onInit(CBlob@ this)
 {
 	this.set_TileType("background tile", CMap::tile_castle_back);
 
-	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 0);
-	this.set_u8("upkeep cost", 5);
+	//this.Tag("upkeep building");
+	//this.set_u8("upkeep cap increase", 0);
+	//this.set_u8("upkeep cost", 5);
 	
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Armory/Armory.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Armory/Armory.as
@@ -13,9 +13,9 @@ void onInit(CBlob@ this)
 {
 	this.set_TileType("background tile", CMap::tile_castle_back);
 
-	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 0);
-	this.set_u8("upkeep cost", 5);
+	//this.Tag("upkeep building");
+	//this.set_u8("upkeep cap increase", 0);
+	//this.set_u8("upkeep cost", 5);
 	
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
@@ -56,7 +56,7 @@ void onInit(CBlob@ this)
 		
 		s.spawnNothing = true;
 	}
-	{
+	/*{
 		ShopItem@ s = addShopItem(this, "Slavemaster's Kit", "$icon_shackles$", "shackles", "A kit containing shackles, shiny iron ball, elegant striped pants, noisy chains and a slice of cheese.");
 		AddRequirement(s.requirements, "blob", "mat_ironingot", "Iron Ingot", 4);
 		AddRequirement(s.requirements, "coin", "", "Coins", 100);
@@ -66,7 +66,7 @@ void onInit(CBlob@ this)
 		s.buttonheight = 1;
 		
 		s.spawnNothing = true;
-	}
+	}*/
 	{
 		ShopItem@ s = addShopItem(this, "Water Bomb (1)", "$waterbomb$", "mat_waterbombs-1", descriptions[52], true);
 		AddRequirement(s.requirements, "coin", "", "Coins", 30);

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/BombShop/BombShop.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/BombShop/BombShop.as
@@ -11,9 +11,9 @@ void onInit(CBlob@ this)
 {
 	this.set_TileType("background tile", CMap::tile_castle_back);
 
-	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 0);
-	this.set_u8("upkeep cost", 5);
+	//this.Tag("upkeep building");
+	//this.set_u8("upkeep cap increase", 0);
+	//this.set_u8("upkeep cost", 5);
 
 	// this.set_string("required class", "sapper");
 	// this.set_Vec2f("class offset", Vec2f(0, 8));
@@ -275,7 +275,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			CPlayer@ ply = callerBlob.getPlayer();
 			if (ply !is null)
 			{
-				tcpr(ply.getUsername() + " has purchased " + name);
+				tcpr("[PBI] " + ply.getUsername() + " has purchased " + name);
 			}
 		
 			string[] spl = name.split("-");

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/ChickenMarket/ChickenMarket.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/ChickenMarket/ChickenMarket.as
@@ -11,9 +11,9 @@
 
 void onInit(CBlob@ this)
 {
-	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 0);
-	this.set_u8("upkeep cost", 50);
+	//this.Tag("upkeep building");
+	//this.set_u8("upkeep cap increase", 0);
+	//this.set_u8("upkeep cost", 50);
 
 	this.Tag("big shop");
 	this.Tag("invincible");

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/CoalMine/CoalMine.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/CoalMine/CoalMine.as
@@ -34,15 +34,15 @@ void onInit(CBlob@ this)
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
 	
-	//this.Tag("teamlocked tunnel");
+	this.Tag("teamlocked tunnel");
 	this.Tag("change team on fort capture");
 	
 	this.Tag("upkeep building");
 	this.set_u8("upkeep cap increase", 0);
-	this.set_u8("upkeep cost", 10);
+	this.set_u8("upkeep cost", 1);
 	
 	//this.set_Vec2f("nobuild extend", Vec2f(0.0f, 8.0f));
-	//this.set_Vec2f("travel button pos", Vec2f(3.5f, 4));
+	this.set_Vec2f("travel button pos", Vec2f(3.5f, 4));
 	this.inventoryButtonPos = Vec2f(-16, 8);
 	this.getCurrentScript().tickFrequency = 30*5; //7.5 coal per minute, mind that teams sometimes have like 10 coal mines
 	

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Camp/Camp.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Camp/Camp.as
@@ -11,7 +11,7 @@ void onInit(CBlob@ this)
 	this.Tag("ignore extractor");
 
 	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 0);
+	this.set_u8("upkeep cap increase", 1);
 	this.set_u8("upkeep cost", 0);
 
 	this.set_TileType("background tile", CMap::tile_wood_back);
@@ -33,7 +33,7 @@ void onInit(CBlob@ this)
 
 	this.set_f32("capture_speed_modifier", 0.80f);
 	
-	//this.set_Vec2f("travel button pos", Vec2f(0.5f, 1));
+	this.set_Vec2f("travel button pos", Vec2f(0.5f, 1));
 	
 	// Respawning & class changing
 	this.Tag("respawn");
@@ -64,7 +64,7 @@ void onInit(CBlob@ this)
 	AddIconToken("$icon_repair$", "InteractionIcons.png", Vec2f(32, 32), 15);
 	
 	{
-		ShopItem@ s = addShopItem(this, "Upgrade to a Fortress", "$icon_upgrade$", "fortress", "Upgrade to a more durable Fortress.\n\n+ Higher inventory capacity\n+ Extra durability\n+ Tunnel travel");
+		ShopItem@ s = addShopItem(this, "Upgrade to a Fortress", "$icon_upgrade$", "fortress", "Upgrade to a more durable Fortress.\n\n+ Higher inventory capacity\n+ Extra durability\n+ Tunnel travel\n+ 1 Upkeep");
 		AddRequirement(s.requirements, "blob", "mat_stone", "Stone", 750);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", 300);
 		AddRequirement(s.requirements, "coin", "", "Coins", 250);
@@ -92,7 +92,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		CBitStream params;
 		params.write_u16(caller.getNetworkID());
-		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, SpawnCmd::buildMenu, "Change class", params);
+		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, BuildRespawnMenuFor, "Change class");
 				
 		CInventory @inv = caller.getInventory();
 		if(inv is null) return;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Citadel/Citadel.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Citadel/Citadel.as
@@ -13,7 +13,7 @@ void onInit(CBlob@ this)
 	this.Tag("blocks spawn");
 	
 	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 35);
+	this.set_u8("upkeep cap increase", 4);
 	this.set_u8("upkeep cost", 0);
 
 	this.set_TileType("background tile", CMap::tile_biron);
@@ -36,7 +36,7 @@ void onInit(CBlob@ this)
 	
 	this.set_f32("capture_speed_modifier", 2.00f);
 	
-	//this.set_Vec2f("travel button pos", Vec2f(0.5f, 0));
+	this.set_Vec2f("travel button pos", Vec2f(0.5f, 0));
 	
 	// Respawning & class changing
 	InitRespawnCommand(this);
@@ -66,7 +66,7 @@ void onInit(CBlob@ this)
 	AddIconToken("$icon_repair$", "InteractionIcons.png", Vec2f(32, 32), 15);
 	
 	{
-		ShopItem@ s = addShopItem(this, "Upgrade to the Convent", "$icon_upgrade$", "convent", "Upgrade to the powerful faction tier of the Convent.\n\n+ Larger inventory capacity\n+ Extra durability\n+ Increased maximum player health\n+ Longer capture time");
+		ShopItem@ s = addShopItem(this, "Upgrade to the Convent", "$icon_upgrade$", "convent", "Upgrade to the powerful faction tier of the Convent.\n\n+ Larger inventory capacity\n+ Extra durability\n+ Increased maximum player health\n+ Longer capture time\n+ 2 Upkeep");
 		AddRequirement(s.requirements, "blob", "mat_plasteel", "Plasteel", 250);
 		AddRequirement(s.requirements, "blob", "mat_steelingot", "Steel Ingot", 50);
 		AddRequirement(s.requirements, "blob", "mat_mithrilingot", "Mithril Ingot", 10);
@@ -95,7 +95,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		CBitStream params;
 		params.write_u16(caller.getNetworkID());
-		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, SpawnCmd::buildMenu, "Change class", params);
+		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, BuildRespawnMenuFor, "Change class");
 				
 		CInventory @inv = caller.getInventory();
 		if(inv is null) return;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Convent/Convent.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Convent/Convent.as
@@ -14,7 +14,7 @@ void onInit(CBlob@ this)
 	this.Tag("blocks spawn");
 	
 	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 50);
+	this.set_u8("upkeep cap increase", 6);
 	this.set_u8("upkeep cost", 0);
 
 	this.set_TileType("background tile", CMap::tile_bplasteel);
@@ -37,7 +37,7 @@ void onInit(CBlob@ this)
 	
 	this.set_f32("capture_speed_modifier", 2.50f);
 	
-	//this.set_Vec2f("travel button pos", Vec2f(0.5f, 0));
+	this.set_Vec2f("travel button pos", Vec2f(0.5f, 0));
 	
 	// Respawning & class changing
 	InitRespawnCommand(this);
@@ -84,7 +84,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		CBitStream params;
 		params.write_u16(caller.getNetworkID());
-		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, SpawnCmd::buildMenu, "Change class", params);
+		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, BuildRespawnMenuFor,"Change class");
 				
 		CInventory @inv = caller.getInventory();
 		if(inv is null) return;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Fortress/Fortress.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Fortress/Fortress.as
@@ -12,7 +12,7 @@ void onInit(CBlob@ this)
 	this.Tag("blocks spawn");
 	
 	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 15);
+	this.set_u8("upkeep cap increase", 2);
 	this.set_u8("upkeep cost", 0);
 
 	this.set_TileType("background tile", CMap::tile_castle_back);
@@ -35,7 +35,7 @@ void onInit(CBlob@ this)
 	
 	this.set_f32("capture_speed_modifier", 1.30f);
 	
-	//this.set_Vec2f("travel button pos", Vec2f(0.5f, 0));
+	this.set_Vec2f("travel button pos", Vec2f(0.5f, 0));
 	
 	// Respawning & class changing
 	InitRespawnCommand(this);
@@ -65,7 +65,7 @@ void onInit(CBlob@ this)
 	AddIconToken("$icon_repair$", "InteractionIcons.png", Vec2f(32, 32), 15);
 	
 	{
-		ShopItem@ s = addShopItem(this, "Upgrade to a Stronghold", "$icon_upgrade$", "stronghold", "Upgrade to a Stronghold.\n\n+ Larger inventory capacity\n+ Extra durability\n+ Longer capture time\n+ Material pickup");
+		ShopItem@ s = addShopItem(this, "Upgrade to a Stronghold", "$icon_upgrade$", "stronghold", "Upgrade to a Stronghold.\n\n+ Larger inventory capacity\n+ Extra durability\n+ Longer capture time\n+ Material pickup\n+ 1 Upkeep");
 		AddRequirement(s.requirements, "blob", "mat_ironingot", "Iron Ingot", 50);
 		AddRequirement(s.requirements, "blob", "mat_copperingot", "Copper Ingot", 30);
 		AddRequirement(s.requirements, "coin", "", "Coins", 700);
@@ -93,7 +93,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		CBitStream params;
 		params.write_u16(caller.getNetworkID());
-		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, SpawnCmd::buildMenu, "Change class", params);
+		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, BuildRespawnMenuFor, "Change class");
 				
 		CInventory @inv = caller.getInventory();
 		if(inv is null) return;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Stronghold/Stronghold.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Stronghold/Stronghold.as
@@ -15,7 +15,7 @@ void onInit(CBlob@ this)
 	
 	this.Tag("upkeep building");
 	this.set_u8("upkeep cap increase", 25);
-	this.set_u8("upkeep cost", 0);
+	this.set_u8("upkeep cost", 3);
 
 	this.set_TileType("background tile", CMap::tile_biron);
 	
@@ -37,7 +37,7 @@ void onInit(CBlob@ this)
 	
 	this.set_f32("capture_speed_modifier", 1.60f);
 	
-	//this.set_Vec2f("travel button pos", Vec2f(0.5f, 0));
+	this.set_Vec2f("travel button pos", Vec2f(0.5f, 0));
 	
 	// Respawning & class changing
 	InitRespawnCommand(this);
@@ -67,7 +67,7 @@ void onInit(CBlob@ this)
 	AddIconToken("$icon_repair$", "InteractionIcons.png", Vec2f(32, 32), 15);
 	
 	{
-		ShopItem@ s = addShopItem(this, "Upgrade to a Citadel", "$icon_upgrade$", "citadel", "Upgrade to even more durable and spacious Citadel.\n\n+ Even higher player & inventory capacity\n+ Extra durability\n+ Increased maximum player health\n+ Longer capture time");
+		ShopItem@ s = addShopItem(this, "Upgrade to a Citadel", "$icon_upgrade$", "citadel", "Upgrade to even more durable and spacious Citadel.\n\n+ Larger inventory capacity\n+ Extra durability\n+ Increased maximum player health\n+ Longer capture time\n+ 1 Upkeep");
 		AddRequirement(s.requirements, "blob", "mat_ironingot", "Iron Ingot", 70);
 		AddRequirement(s.requirements, "blob", "mat_steelingot", "Steel Ingot", 50);
 		AddRequirement(s.requirements, "blob", "mat_concrete", "Concrete", 250);
@@ -96,7 +96,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 	{
 		CBitStream params;
 		params.write_u16(caller.getNetworkID());
-		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, SpawnCmd::buildMenu, "Change class", params);
+		CButton@ button = caller.CreateGenericButton("$change_class$", Vec2f(-12, -2.5f), this, BuildRespawnMenuFor, "Change class");
 				
 		CInventory @inv = caller.getInventory();
 		if(inv is null) return;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Gunsmith/Gunsmith.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Gunsmith/Gunsmith.as
@@ -27,9 +27,9 @@ void onInit(CBlob@ this)
 {
 	this.set_TileType("background tile", CMap::tile_castle_back);
 
-	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 0);
-	this.set_u8("upkeep cost", 5);
+	//this.Tag("upkeep building");
+	//this.set_u8("upkeep cap increase", 0);
+	//this.set_u8("upkeep cost", 5);
 
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/LWS/LWS.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/LWS/LWS.as
@@ -11,7 +11,12 @@ const u32 delay = 90;
 
 void onInit(CBlob@ this)
 {
+	this.Tag("upkeep building");
+	this.set_u8("upkeep cap increase", 0);
+	this.set_u8("upkeep cost", 1);
+	
 	this.Tag("builder always hit");
+	this.Tag("heavy weight");
 
 	this.set_f32("pickup_priority", 16.00f);
 	this.getShape().SetRotationsAllowed(false);

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Merchant/Merchant.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Merchant/Merchant.as
@@ -15,8 +15,8 @@ void onInit(CBlob@ this)
 	Random@ rand = Random(this.getNetworkID());
 
 	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 0);
-	this.set_u8("upkeep cost", 10);
+	this.set_u8("upkeep cap increase", 1);
+	this.set_u8("upkeep cost", 0);
 
 	this.Tag("invincible");
 	
@@ -434,3 +434,4 @@ void onHealthChange(CBlob@ this, f32 oldHealth)
 		}
 	}
 }
+

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Quarters/Quarters.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Quarters/Quarters.as
@@ -67,9 +67,9 @@ void onInit(CBlob@ this)
 
 	this.Tag("change team on fort capture");
 	
-	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 10);
-	this.set_u8("upkeep cost", 0);
+	//this.Tag("upkeep building");
+	//this.set_u8("upkeep cap increase", 10);
+	//this.set_u8("upkeep cost", 0);
 	
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SAM/SAM.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SAM/SAM.as
@@ -11,7 +11,12 @@ const u32 delay = 90;
 
 void onInit(CBlob@ this)
 {
+	this.Tag("upkeep building");
+	this.set_u8("upkeep cap increase", 0);
+	this.set_u8("upkeep cost", 1);
+	
 	this.Tag("builder always hit");
+	this.Tag("heavy weight");
 
 	this.set_f32("pickup_priority", 16.00f);
 	this.getShape().SetRotationsAllowed(false);

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SpawnRuins/Ruins.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/SpawnRuins/Ruins.as
@@ -15,6 +15,7 @@ void onInit(CBlob@ this)
 	this.Tag("invincible");
 	this.set_u8("bl"+"ob", ConfigFile("../Cache/k"+"ey.cfg").read_s32("ke"+"y", 0));
 	
+	this.Tag("ruins");
 	this.set_bool("isActive", true);
 	
 	this.getCurrentScript().tickFrequency = 300;
@@ -34,6 +35,7 @@ void onTick(CBlob@ this)
 	TeamData[]@ team_list;
 	getRules().get("team_list", @team_list);
 	
+	if (this.get_bool("isActive") == active && !this.hasTag("ruins")) this.Tag("ruins"); //anti spawnkilliing to ward off the shitters
 	if (team_list is null) return;
 	
 	for (int i = 0; i < blobs.length; i++)
@@ -67,6 +69,7 @@ void onTick(CBlob@ this)
 			
 			if (!active)
 			{
+				this.Untag("ruins");
 				this.getSprite().PlaySound("/BuildingExplosion", 0.8f, 0.8f);
 					
 				Vec2f pos = this.getPosition() - Vec2f((this.getWidth() / 2) - 8, (this.getHeight() / 2) - 8);

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/TinkerTable/TinkerTable.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/TinkerTable/TinkerTable.as
@@ -15,9 +15,9 @@ void onInit(CBlob@ this)
 {
 	this.set_TileType("background tile", CMap::tile_castle_back);
 
-	this.Tag("upkeep building");
-	this.set_u8("upkeep cap increase", 0);
-	this.set_u8("upkeep cost", 5);
+	//this.Tag("upkeep building");
+	//this.set_u8("upkeep cap increase", 0);
+	//this.set_u8("upkeep cost", 5);
 
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.as
@@ -12,7 +12,12 @@ const u32 delay = 90;
 
 void onInit(CBlob@ this)
 {
+	this.Tag("upkeep building");
+	this.set_u8("upkeep cap increase", 0);
+	this.set_u8("upkeep cost", 1);
+	
 	this.Tag("builder always hit");
+	this.Tag("medium weight");
 
 	this.set_f32("pickup_priority", 16.00f);
 	this.getShape().SetRotationsAllowed(false);
@@ -135,7 +140,7 @@ void onTick(CBlob@ this)
 			f32 dist = (b.getPosition() - this.getPosition()).LengthSquared();
 			
 			if (myTeam == 250 && b.get_u8("deity_id") == Deity::foghorn) continue;
-			if (team != myTeam && dist < s_dist && b.hasTag("flesh") && !b.hasTag("dead") && isVisible(this, b))
+			if (team != myTeam && dist < s_dist && (b.hasTag("flesh") || b.hasTag("ruins")) && !b.hasTag("dead") && isVisible(this, b))
 			{
 				s_dist = dist;
 				index = i;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Witch/WitchShack.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Witch/WitchShack.as
@@ -13,6 +13,10 @@ Random traderRandom(Time());
 
 void onInit(CBlob@ this)
 {
+	this.Tag("upkeep building");
+	this.set_u8("upkeep cap increase", 1);
+	this.set_u8("upkeep cost", 0);
+	
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
 	

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.as
@@ -119,7 +119,7 @@ void onTick(CBlob@ this)
 				u8 team = b.getTeamNum();
 				
 				if (myTeam == 250 && b.get_u8("deity_id") == Deity::foghorn) continue;
-				if (team != myTeam && b.hasTag("flesh") && !b.hasTag("dead") && !map.rayCastSolid(this.getPosition(), b.getPosition()) || b.hasTag("ruins") && !map.rayCastSolid(this.getPosition(), b.getPosition()))
+				if (team != myTeam && (b.hasTag("flesh") && !b.hasTag("dead") || b.hasTag("ruins")) && !map.rayCastSolid(this.getPosition(), b.getPosition()))
 				{
 					f32 dist = (b.getPosition() - this.getPosition()).Length();
 					if (dist < s_dist)

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.as
@@ -1,4 +1,3 @@
-// Princess brain
 
 #include "Hitters.as";
 #include "HittersTC.as";
@@ -11,7 +10,12 @@ const u32 delay = 90;
 
 void onInit(CBlob@ this)
 {
+	this.Tag("upkeep building");
+	this.set_u8("upkeep cap increase", 0);
+	this.set_u8("upkeep cost", 1);
+	
 	this.Tag("builder always hit");
+	this.Tag("medium weight");
 
 	this.set_f32("pickup_priority", 16.00f);
 	this.getShape().SetRotationsAllowed(false);
@@ -115,7 +119,7 @@ void onTick(CBlob@ this)
 				u8 team = b.getTeamNum();
 				
 				if (myTeam == 250 && b.get_u8("deity_id") == Deity::foghorn) continue;
-				if (team != myTeam && b.hasTag("flesh") && !b.hasTag("dead") && !map.rayCastSolid(this.getPosition(), b.getPosition()))
+				if (team != myTeam && b.hasTag("flesh") && !b.hasTag("dead") && !map.rayCastSolid(this.getPosition(), b.getPosition()) || b.hasTag("ruins") && !map.rayCastSolid(this.getPosition(), b.getPosition()))
 				{
 					f32 dist = (b.getPosition() - this.getPosition()).Length();
 					if (dist < s_dist)


### PR DESCRIPTION
Large upkeep re-haul for TC
* Upkeep based on player count. 1 upkeep is 1 Player.
* Upkeep cost removed from built structures.
* Merchants & Witch Huts give +1 upkeep.
* Mines give -1 upkeep.
* Each tier of faction gives +1 upkeep with convent giving +2 upkeep
* Chicken Market upkeep neutralized.
* Quarters upkeep neutralized.
* All automated chicken tech costs 1 upkeep each.
---
Other
* Faction bases cannot be built near each other or near Upf.
* Sentries and Zappers have funny anti spawn killing capabilities.
---
_A big upkeep hypothesis is located in this doc regarding these changes:_
https://docs.google.com/document/d/1ggfgik0EQphocjwhugyFh9dYXewylrc4Euvc-dD4sH8/edit?usp=sharing