### PR TITLE
Small quality of life changes

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderAutoPickup.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderAutoPickup.as
@@ -17,6 +17,7 @@ void Take(CBlob@ this, CBlob@ blob)
 			bool add = true;
 			if (blob.hasTag("ammo")) //only add ammo if we have something that can use it.
 			{
+				add = false;
 				CBlob@[] items;
 				if (this.getCarriedBlob() != null)
 				{
@@ -37,7 +38,6 @@ void Take(CBlob@ this, CBlob@ blob)
 						add = true;
 						break;
 					}
-					add = false;
 				}
 			}
 			if(!add){return;}

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderAutoPickup.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderAutoPickup.as
@@ -14,6 +14,33 @@ void Take(CBlob@ this, CBlob@ blob)
 	{
 		if ((this.getDamageOwnerPlayer() is blob.getPlayer()) || getGameTime() > blob.get_u32("autopick time"))
 		{
+			bool add = true;
+			if (blob.hasTag("ammo")) //only add ammo if we have something that can use it.
+			{
+				CBlob@[] items;
+				if (this.getCarriedBlob() != null)
+				{
+					items.push_back(this.getCarriedBlob());
+				}
+				CInventory@ inv = this.getInventory();
+				for (int i = 0; i < inv.getItemsCount(); i++)
+				{
+					CBlob@ item = inv.getItem(i);
+					items.push_back(item);
+				}
+				for(int i = 0; i < items.size(); i++)
+				{
+					CBlob@ item = items[i];
+					string ammoType = item.get_string("gun_ammoItem");
+					if(ammoType == blob.getName())
+					{
+						add = true;
+						break;
+					}
+					add = false;
+				}
+			}
+			if(!add){return;}
 			if (!this.server_PutInInventory(blob))
 			{
 				// we couldn't fit it in

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/ForceFeed.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/ForceFeed.as
@@ -18,6 +18,8 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		{
 			button.SetEnabled(carried.hasTag("forcefeed_always") || canBeForceFed(this));
 		}
+
+		button.offset = Vec2f(0,-16);
 	}
 }
 

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Equipment/Jetpack/jetpack_effect.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Equipment/Jetpack/jetpack_effect.as
@@ -40,7 +40,7 @@ void onTick(CBlob@ this)
 	
 	if (!flying)
 	{
-		if (this.isKeyPressed(key_action3) && !isknocked)
+		if (this.isKeyJustPressed(key_up) && !isknocked && !this.isOnGround())
 		{
 			Vec2f dir = this.getAimPos() - this.getPosition();
 			dir.Normalize();


### PR DESCRIPTION
[change] - Changed the position of the ForceFeed button as to not overlap with the inventory button
[change] - Changed the pickup system to ignore ammo unless you have a gun in your inventory that uses said ammo
[change] - Changed the Jetpack activation system to be the same key as jump, allowing for a double jump still, while also avoiding key conflicts with building and activating items.