### PR TITLE
Howitzer unnerf

### DIFF
--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Howitzer/Howitzer.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Howitzer/Howitzer.as
@@ -195,7 +195,7 @@ void Vehicle_onFire(CBlob@ this, VehicleInfo@ v, CBlob@ bullet, const u8 _unused
 		angle = angle * (this.isFacingLeft() ? -1 : 1);
 		angle += ((XORRandom(200) - 100) / 100.0f) * 4.0f;
 		
-		Vec2f vel = Vec2f((18.0f + (XORRandom(100) / 100.0f) * 2.0f ) * (this.isFacingLeft() ? -1 : 1), 0.0f).RotateBy(angle);
+		Vec2f vel = Vec2f((24.0f + (XORRandom(100) / 100.0f) * 2.0f ) * (this.isFacingLeft() ? -1 : 1), 0.0f).RotateBy(angle);
 		bullet.setVelocity(vel);
 		
 		Vec2f offset = Vec2f((this.isFacingLeft() ? -1 : 1) * 16, 0);

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Howitzer/HowitzerShell.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Howitzer/HowitzerShell.as
@@ -147,7 +147,7 @@ void DoExplosion(CBlob@ this)
 	this.set_f32("map_damage_radius", 32.0f);
 	this.set_f32("map_damage_ratio", 0.25f);
 	
-	Explode(this, 64.0f, 4.0f);
+	Explode(this, 64.0f, 6.0f);
 	
 	for (int i = 0; i < 8; i++) 
 	{
@@ -155,7 +155,7 @@ void DoExplosion(CBlob@ this)
 		dir.x *= 2;
 		dir.Normalize();
 		
-		LinearExplosion(this, dir, 32.0f + XORRandom(16) + (modifier * 8), 24 + XORRandom(24), 4, 3.00f, Hitters::explosion);
+		LinearExplosion(this, dir, 32.0f + XORRandom(16) + (modifier * 8), 24 + XORRandom(24), 4, 4.00f, Hitters::explosion);
 	}
 	
 	if(isClient())

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Weapons/SmallRocket/SmallRocket.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Weapons/SmallRocket/SmallRocket.as
@@ -104,7 +104,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
 	if (isServer())
 	{
-		if (this.getTickSinceCreated() > 10 && (solid ? true : (blob !is null && blob.isCollidable())))
+		if (this.getTickSinceCreated() > 10 && (solid ? true : (blob !is null && blob.isCollidable() && this.getTeamNum() != blob.getTeamNum())))
 		{
 			this.server_Die();
 		}


### PR DESCRIPTION
Not asking for much here. Just want the howitzer to be brought back into game play occasionally. Its a bit under powered since the last nerf a few years ago. 
* Ups the range of the howitzer to old range (slightly less technically).
* Ups the damage of the howitzer shell to current day balance.
* Also fixes an old bug(?) where fired rockets collided midair with themselves.
