### PR TITLE
Coal dusting

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Explosives/Material_Dynamite.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Explosives/Material_Dynamite.as
@@ -1,28 +1,45 @@
+#include "Hitters.as";
 void onInit(CBlob@ this)
 {
 	this.Tag("explosive");
+	this.set_bool("lite", true);
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 {
-    if (cmd == this.getCommandID("activate"))
-    {
-        if(isServer())
+	if (cmd == this.getCommandID("activate") && this.get_bool("lite"))
+	{
+		this.set_bool("lite", false);
+		if(isServer())
         {
     		AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
-            if(point is null){return;}
+			if(point is null){return;}
     		CBlob@ holder = point.getOccupied();
 
-            if(holder !is null && this !is null)
-            {
-                CBlob@ blob = server_CreateBlob("dynamite", this.getTeamNum(), this.getPosition());
-                holder.server_Pickup(blob);
-                this.server_Die();
-				
+			if(holder !is null && this !is null)
+			{
+				CBlob@ blob = server_CreateBlob("dynamite", this.getTeamNum(), this.getPosition());
+				holder.server_Pickup(blob);
+
 				CPlayer@ activator = holder.getPlayer();
 				string activatorName = activator !is null ? (activator.getUsername() + " (team " + activator.getTeamNum() + ")") : "<unknown>";
 				printf(activatorName + " has activated " + this.getName());
-            }
-        }
-    }
+			}
+			else
+			{
+				CBlob@ blob = server_CreateBlob("dynamite", this.getTeamNum(), this.getPosition());
+				blob.server_Die();
+			}
+			this.server_Die();
+		}
+	}
+}
+
+f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
+{
+	if (customData == Hitters::explosion) //chain reaction
+	{
+		this.SendCommand(this.getCommandID("activate"));
+	}
+	return damage;
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Explosives/Material_Dynamite.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Explosives/Material_Dynamite.as
@@ -11,7 +11,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 	{
 		this.set_bool("lite", false);
 		if(isServer())
-        {
+		{
     		AttachmentPoint@ point = this.getAttachments().getAttachmentPointByName("PICKUP");
 			if(point is null){return;}
     		CBlob@ holder = point.getOccupied();

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Coal.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Coal.as
@@ -1,8 +1,8 @@
 void onInit(CBlob@ this)
-{	
-	this.maxQuantity = 50;	
+{
+	this.maxQuantity = 50;
 	this.set_u8("fuel_energy", 20);
-	
+
 	this.getCurrentScript().tickFrequency = 1;
 }
 
@@ -12,17 +12,17 @@ void onTick(CBlob@ this)
 {
 	Vec2f vel = this.getOldVelocity();
 	f32 vellen = vel.getLength();
-	
-	if (vellen > 5.00f)
+
+	if (vellen > 5.00f && this.hasTag("dusted"))
 	{
 		if (isServer())
 		{
 			this.server_SetQuantity(Maths::Clamp(this.getQuantity() - dust_quantity, 0, this.maxQuantity));
 			CBlob@ dust = server_CreateBlob("coal", -1, this.getPosition());
-			
+
 			dust.setVelocity((vel * 0.74f) + getRandomVelocity(0, XORRandom(vellen * 25) * 0.02f, 360));
 		}
-		
+
 		if (isClient())
 		{
 			this.getSprite().PlaySound("sand_fall.ogg", 1.00f, 0.60f);

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/Coal/Coal.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/Coal/Coal.as
@@ -82,6 +82,7 @@ void onTick(CBlob@ this)
 			CBlob@ blob = server_CreateBlob("mat_coal", -1, this.getPosition());
 			blob.server_SetQuantity(1 + XORRandom(6));
 			blob.Tag("dusted");
+			blob.setInventoryName("Coal Dust");
 		}
 	}
 }

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/Coal/Coal.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/Coal/Coal.as
@@ -3,13 +3,13 @@
 #include "Explosion.as";
 #include "ArcherCommon.as";
 
-// string[] particles = 
+// string[] particles =
 // {
 	// "LargeSmoke.png",
 	// "Explosion.png"
 // };
 
-string[] particles = 
+string[] particles =
 {
 	"SmallSmoke1.png",
 	"SmallSmoke2.png",
@@ -32,9 +32,9 @@ void onInit(CBlob@ this)
 	this.set_u8("custom_hitter", Hitters::explosion);
 
 	this.Tag("map_damage_dirt");
-	
+
 	if (!this.exists("toxicity")) this.set_f32("toxicity", 0.80f);
-	
+
 	// this.SetMapEdgeFlags(CBlob::map_collide_left | CBlob::map_collide_right | CBlob::map_collide_up | CBlob::map_collide_down);
 	this.SetMapEdgeFlags(CBlob::map_collide_sides);
 	if(isClient())
@@ -57,7 +57,7 @@ void onTick(CBlob@ this)
 	if(isClient())
 	{
 		CParticle@ particle = ParticleAnimated("Coal.png", this.getPosition(), this.getOldVelocity() / 7, 1.0f, 1, 6, 0.0f, false);
-		if (particle !is null) 
+		if (particle !is null)
 		{
 			particle.frame = XORRandom(7);
 			particle.collides = false;
@@ -81,9 +81,9 @@ void onTick(CBlob@ this)
 			this.server_Die();
 			CBlob@ blob = server_CreateBlob("mat_coal", -1, this.getPosition());
 			blob.server_SetQuantity(1 + XORRandom(6));
+			blob.Tag("dusted");
 		}
 	}
-
 }
 
 void DoExplosion(CBlob@ this)
@@ -94,41 +94,41 @@ void DoExplosion(CBlob@ this)
 		addToNextTick(this, rules, DoExplosion);
 		return;
 	}
-	
+
 	Random@ random = Random(this.getNetworkID());
 	f32 angle = this.get_f32("bomb angle");
 
 	this.set_f32("map_damage_radius", (32.0f + random.NextRanged(32)));
 	this.set_f32("map_damage_ratio", 0.25f);
 	Explode(this, 40.0f, 1.2f);
-	
+
 	Vec2f pos = this.getPosition();
 	CMap@ map = getMap();
-		
+
 	if (isServer())
 	{
 		CBlob@[] blobs;
-		
+
 		if (map.getBlobsInRadius(pos, 15.0f, @blobs))
 		{
 			for (int i = 0; i < blobs.length; i++)
-			{		
+			{
 				CBlob@ blob = blobs[i];
-				if (blob !is null) 
+				if (blob !is null)
 				{
 					map.server_setFireWorldspace(blob.getPosition(), true);
 					blob.server_Hit(blob, blob.getPosition(), Vec2f(0, 0), 0.5f, Hitters::fire);
 				}
 			}
 		}
-	}	
-	
+	}
+
 	if (isClient())
 	{
 		// this.getSprite().PlaySound("shockmine_explode.ogg", 0.80f, 1.10f);
 		ShakeScreen(100, 60, this.getPosition());
 
-		if (this.isOnScreen()) 
+		if (this.isOnScreen())
 		{
 			for (int i = 0; i < 4; i++)
 			{
@@ -136,7 +136,7 @@ void DoExplosion(CBlob@ this)
 			}
 		}
 	}
-	
+
 	this.getSprite().Gib();
 }
 
@@ -173,7 +173,6 @@ void onDie(CBlob@ this)
 	{
 		DoExplosion(this);
 	}
-	
 }
 
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Grinder/Grinder.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Grinder/Grinder.as
@@ -221,6 +221,7 @@ void Blend(CBlob@ this, CBlob@ blob)
 		case -324721731://mat_coal
 		{
 			blob.Tag("dusted");
+			blob.setInventoryName("Coal Dust");
 			this.server_PutInInventory(blob);
 
 			if(isClient())

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Grinder/Grinder.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Grinder/Grinder.as
@@ -7,7 +7,7 @@ const int MAX_GRINDABLE_AT_ONCE = 5;
 void onInit(CSprite@ this)
 {
 	this.SetZ(10);
-	
+
 	this.SetEmitSound("Grinder_Loop.ogg");
 	this.SetEmitSoundVolume(0.3f);
 	this.SetEmitSoundSpeed(0.9f);
@@ -24,7 +24,7 @@ void onInit(CSprite@ this)
 		chop_left.SetRelativeZ(-1.0f);
 		chop_left.SetOffset(Vec2f(5.0f, -1.0f));
 	}
-	
+
 	CSpriteLayer@ chop_right = this.addSpriteLayer("chop_right", "/Saw.png", 16, 16);
 
 	if (chop_right !is null)
@@ -38,16 +38,16 @@ void onInit(CSprite@ this)
 	}
 }
 void onInit(CBlob@ this)
-{	
+{
 	this.Tag("builder always hit");
-	
+
 	this.getShape().SetOffset(Vec2f(0, 4));
-		
+
 	{
 		Vec2f offset(-24, 8);
-	
-		Vec2f[] shape = 
-		{ 
+
+		Vec2f[] shape =
+		{
 			Vec2f(0.0f, 0.0f) - offset,
 			Vec2f(8.0f, 0.0f) - offset,
 			Vec2f(8.0f, 23.0f) - offset,
@@ -55,12 +55,12 @@ void onInit(CBlob@ this)
 		};
 		this.getShape().AddShape(shape);
 	}
-	
+
 	{
 		Vec2f offset(8, 8);
-	
-		Vec2f[] shape = 
-		{ 
+
+		Vec2f[] shape =
+		{
 			Vec2f(0.0f, 0.0f) - offset,
 			Vec2f(8.0f, 0.0f) - offset,
 			Vec2f(8.0f, 23.0f) - offset,
@@ -68,7 +68,7 @@ void onInit(CBlob@ this)
 		};
 		this.getShape().AddShape(shape);
 	}
-	
+
 	this.set_TileType("background tile", CMap::tile_castle_back);
 	this.getShape().getConsts().mapCollisions = false;
 	this.getCurrentScript().tickFrequency = 5;
@@ -82,22 +82,21 @@ void onTick(CBlob@ this)
 		ShapeConsts@ consts = this.getShape().getConsts();
 		consts.collidable = true;
 	}
-	
 
 	CBlob@[] blobs;
-	if (getMap().getBlobsInRadius(this.getPosition()+Vec2f(0,-2) ,6.0f, @blobs))
+	if (getMap().getBlobsInRadius(this.getPosition()+Vec2f(0,-2) ,6.4f, @blobs))
 	{
 		int length = (blobs.length > MAX_GRINDABLE_AT_ONCE ? MAX_GRINDABLE_AT_ONCE : blobs.length);
-		
+
 		for (uint i = 0; i < length; i++)
 		{
 			CBlob@ blob = blobs[i];
 			if (blob is null) { continue; }
-			
+
 			if (canSaw(this, blob))
 			{
 				Blend(this, blob);
-				if (isServer()) 
+				if (isServer())
 				{ 
 					this.server_Hit(blob, blob.getPosition(), Vec2f(0, -2), 2.00f, Hitters::saw, true); 
 				}
@@ -115,10 +114,8 @@ void onTick(CBlob@ this)
 	}
 }
 
-
 void onTick(CSprite@ this)
 {
-
 	if (this.getBlob().getTickSinceCreated() < 90) { return; }
 
 	CSpriteLayer@ chop_left = this.getSpriteLayer("chop_left");
@@ -130,7 +127,7 @@ void onTick(CSprite@ this)
 
 bool canSaw(CBlob@ this, CBlob@ blob)
 {
-	if (this.getTickSinceCreated() < 90 || blob.hasTag("sawed") || blob.getShape().isStatic() || blob.getName() == "grinder" || (blob.getName() == "mat_stone" ? false : blob.hasTag("invincible"))) return false;
+	if (this.getTickSinceCreated() < 90 || blob.hasTag("sawed") || blob.getShape().isStatic() || blob.getName() == "grinder" || (blob.getName() == "mat_stone" || blob.getName() == "mat_coal" ? false : blob.hasTag("invincible"))) return false;
 
 	if (blob.hasTag("flesh") && isClient() && !g_kidssafe)
 	{
@@ -143,7 +140,7 @@ bool canSaw(CBlob@ this, CBlob@ blob)
 		
 		sprite.SetAnimation("blood");
 	}
-	
+
 	return true;
 }
 
@@ -154,7 +151,7 @@ void Blend(CBlob@ this, CBlob@ blob)
 	bool kill = false;
 	const string name = blob.getName();
 	const int hash = name.getHash();
-	
+
 	switch(hash)
 	{
 		case 1062293841://log
@@ -163,7 +160,7 @@ void Blend(CBlob@ this, CBlob@ blob)
 			{
 				MakeMat(this, this.getPosition(), "mat_wood", 60 + XORRandom(40));
 			}
-		
+
 			this.getSprite().PlaySound("SawLog.ogg", 0.8f, 0.9f);
 			kill = true;
 		}
@@ -174,7 +171,7 @@ void Blend(CBlob@ this, CBlob@ blob)
 			if (isServer())
 			{
 				u32 quantity = blob.getQuantity();
-			
+
 				MakeMat(this, this.getPosition(), "mat_stone", 		quantity * 0.50f + XORRandom(quantity * 0.25f));
 				MakeMat(this, this.getPosition(), "mat_concrete", 	quantity * 0.125f + XORRandom(quantity * 0.125f));
 				MakeMat(this, this.getPosition(), "mat_iron", 		XORRandom(quantity * 0.20f));
@@ -183,12 +180,12 @@ void Blend(CBlob@ this, CBlob@ blob)
 				MakeMat(this, this.getPosition(), "mat_gold",	 	XORRandom(quantity * 0.06f));
 				MakeMat(this, this.getPosition(), "mat_mithril", 	XORRandom(quantity * 0.05f));
 			}
-		
+
 			if(isClient())
 			{
 				this.getSprite().PlaySound("rocks_explode" + (1 + XORRandom(2)) + ".ogg", 1.5f, 1.0f);
-				
-				if (XORRandom(100) < 75) 
+
+				if (XORRandom(100) < 75)
 				{
 					ParticleAnimated("Smoke.png", this.getPosition() + Vec2f(8 - XORRandom(16), 8 - XORRandom(16)), Vec2f((100 - XORRandom(200)) / 100.0f, 0.5f), 0.0f, 1.5f, 3, 0.0f, true);
 				}
@@ -203,8 +200,6 @@ void Blend(CBlob@ this, CBlob@ blob)
 			{
 				MakeMat(this, this.getPosition(), "mat_plasteel", 5 + XORRandom(20));
 				MakeMat(this, this.getPosition(), "mat_steelingot", 1 + XORRandom(3));
-				
-				
 			}
 			kill = true;
 		}
@@ -217,9 +212,26 @@ void Blend(CBlob@ this, CBlob@ blob)
 			{
 				MakeMat(this, this.getPosition(), "mat_meat", 20 + XORRandom(10));
 			}
-			
+
 			this.getSprite().PlaySound("SawLog.ogg", 0.8f, 1.0f);
 			kill = true;
+		}
+		break;
+
+		case -324721731://mat_coal
+		{
+			blob.Tag("dusted");
+			this.server_PutInInventory(blob);
+
+			if(isClient())
+			{
+				this.getSprite().PlaySound("rocks_explode" + (1 + XORRandom(2)) + ".ogg", 1.5f, 1.0f);
+
+				if (XORRandom(100) < 75)
+				{
+					ParticleAnimated("LargeSmoke.png", this.getPosition() + Vec2f(8 - XORRandom(16), 8 - XORRandom(16)), Vec2f((100 - XORRandom(200)) / 100.0f, 0.5f), 0.0f, 1.5f, 3, 0.0f, true);
+				}
+			}
 		}
 		break;
 
@@ -231,11 +243,11 @@ void Blend(CBlob@ this, CBlob@ blob)
 				{
 					f32 amount = ((blob.getRadius() + XORRandom(blob.getMass() / 3.0f)) / blob.getInitialHealth()) * 0.35f;
 					amount += XORRandom(amount) * 0.50f;
-					
+
 					// print("" + amount);
-					
+
 					blob.setVelocity(Vec2f(1 - XORRandom(2), -0.25f));
-					
+
 					MakeMat(this, this.getPosition(), "mat_meat", amount);
 				}
 			}
@@ -243,9 +255,9 @@ void Blend(CBlob@ this, CBlob@ blob)
 			{
 				if (isServer())
 				{
-					MakeMat(this, this.getPosition(), "mat_iron", 20 + XORRandom(60));
-					MakeMat(this, this.getPosition(), "mat_wood", 10 + XORRandom(40));
-					
+					MakeMat(this, this.getPosition(), "mat_ironingot", 1);
+					MakeMat(this, this.getPosition(), "mat_wood", 10 + XORRandom(30));
+
 					kill = true;
 				}
 			}
@@ -258,18 +270,17 @@ void Blend(CBlob@ this, CBlob@ blob)
 		}
 		break;
 	}
-	
-	
+
 	if (kill)
 	{
 		blob.Tag("sawed");
-	
+
 		CSprite@ s = blob.getSprite();
 		if (s !is null)
 		{
 			s.Gib();
 		}
-	
+
 		blob.server_SetHealth(-1.0f);
 		blob.server_Die();
 	}
@@ -283,7 +294,7 @@ void Blend(CBlob@ this, CBlob@ blob)
 	// Vec2f bpos = blob.getPosition();
 
 	// if ((bpos.x > pos.x + 9) || (bpos.x < pos.x - 9) || bpos.y > pos.y) return;
-	
+
 	// if (canSaw(this, blob))
 	// {
 		// Blend(this, blob);

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Weapons/Dynamite/Dynamite.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Weapons/Dynamite/Dynamite.as
@@ -67,20 +67,16 @@ bool canBePutInInventory(CBlob@ this, CBlob@ inventoryBlob)
 
 f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
 {
-	// No chain reactions, as they cause crashes
-	if (customData == Hitters::explosion || customData == Hitters::water || customData == Hitters::water_stun)
+	if (customData == Hitters::water || customData == Hitters::water_stun)
 	{
 		this.Tag("exploded");
 		if (isServer())
 		{
-			if (customData != Hitters::explosion)
-			{
-				CBlob@ blob = server_CreateBlob("mat_dynamite", this.getTeamNum(), this.getPosition());
-			}
+			CBlob@ blob = server_CreateBlob("mat_dynamite", this.getTeamNum(), this.getPosition());
 			this.server_Die();
 		}
 	}
-	
+
 	return damage;
 }
 
@@ -98,7 +94,7 @@ void DoExplosion(CBlob@ this)
 		addToNextTick(this, rules, DoExplosion);
 		return;
 	}
-	
+
 	if (this.hasTag("exploded")) return;
 
 	f32 random = XORRandom(16);
@@ -122,7 +118,6 @@ void DoExplosion(CBlob@ this)
 
 	if(isClient())
 	{
-
 
 		Vec2f pos = this.getPosition();
 		CMap@ map = getMap();


### PR DESCRIPTION
Intended to make coal much more compatible with factories.
- Coal only becomes dust if it has been thrown in a grinder before hand.
- Also fixes the grinder itself so items do not get stuck in the corners.
- Unrelated change- dynamite will explode if blown up from other explosions (chain reactions).