### PR TITLE
Gauss rifle nerf

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/TinkerTable/TinkerTable.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/TinkerTable/TinkerTable.as
@@ -199,12 +199,11 @@ void onInit(CBlob@ this)
 		s.spawnNothing = true;
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Gauss Rifle", "$icon_gaussrifle$", "gaussrifle", "A modified toy used to kill people.\n\nUses Steel Ingots.");
+		ShopItem@ s = addShopItem(this, "Gauss Rifle", "$icon_gaussrifle$", "gaussrifle", "A modified toy used to kill people.\n\nUses Mithril Ingots.");
 		AddRequirement(s.requirements, "blob", "mat_steelingot", "Steel Ingot", 10);
 		AddRequirement(s.requirements, "blob", "mat_mithril", "Mithril", 50);
 		AddRequirement(s.requirements, "blob", "mat_copperwire", "Copper Wire", 10);
 		AddRequirement(s.requirements, "coin", "", "Coins", 850);
-
 
 		s.customButton = true;
 		s.buttonwidth = 2;
@@ -255,7 +254,6 @@ void onInit(CBlob@ this)
 		ShopItem@ s = addShopItem(this, "Acidthrower", "$icon_acidthrower$", "acidthrower", "A tool used for dissolving plants, buildings and people.\n\nUses Acid.");
 		AddRequirement(s.requirements, "blob", "mat_steelingot", "Steel Ingot", 10);
 		AddRequirement(s.requirements, "coin", "", "Coins", 1250);
-
 
 		s.customButton = true;
 		s.buttonwidth = 2;

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/GaussRifle/GaussRifle.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/GaussRifle/GaussRifle.as
@@ -7,7 +7,7 @@ void onInit(CBlob@ this)
 	GunInitRaycast(
 		this,
 		true,				//If true, gun will be fully automatic and players will be able to just hold the fire button
-		3.00f,				//Weapon damage / projectile blob name
+		1.50f,				//Weapon damage / projectile blob name
 		1000.0f,			//Weapon raycast range
 		30,					//Weapon fire delay, in ticks
 		1,					//Weapon clip size
@@ -17,7 +17,7 @@ void onInit(CBlob@ this)
 		0,					//For shotguns: Additional delay to reload end
 		13,					// Bullet count - for shotguns
 		0.60f,				// Bullet Jitter
-		"mat_steelingot",	//Ammo item blob name
+		"mat_mithrilingot",	//Ammo item blob name
 		false,				//If true, firing sound will be looped until player stops firing
 		SoundInfo("GaussRifle_Shoot", 1, 1.00f, 1.00f),		//Sound to play when firing
 		SoundInfo("BazookaCycle", 1, 0.70f, 0.80f),	//Sound to play when reloading
@@ -25,10 +25,10 @@ void onInit(CBlob@ this)
 		20,					//Delay for the delayed sound, in ticks
 		Vec2f(-8.0f,2.0f)	//Visual offset for raycast bullets
 	);
-	
+
 	this.set_string("gun_tracerName", "GaussRifle_Tracer.png");
 	this.set_u8("gun_hitter", HittersTC::railgun_lance);
-	
+
 	this.Tag("medium weight");
 }
 


### PR DESCRIPTION
Resolves Issue #99 
- Halved damage of Gauss.
- Gauss uses mithril ingots as ammunition instead.