### PR TITLE
Material decay

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_BanditAmmo.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_BanditAmmo.as
@@ -1,5 +1,9 @@
 void onInit(CBlob@ this)
-{	
+{
+	if (isServer())
+	{
+		this.set_u8('decay step', 7);
+	}
 	this.Tag("ammo");
 
 	this.maxQuantity = 40;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_BanditAmmo.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_BanditAmmo.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_banditammo
 @$scripts                              = MaterialStandard.as;
 										 MaterialMerge.as;
                                          Material_BanditAmmo.as;
+										 DecayQuantity.as;
 										 MarkForPickup_Builder;
 										 MarkForPickup_Archer;
 										 MarkForPickup_Knight;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_GatlingAmmo.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_GatlingAmmo.as
@@ -1,7 +1,11 @@
 void onInit(CBlob@ this)
 {
+	if (isServer())
+	{
+		this.set_u8('decay step', 7);
+	}
 	this.Tag("ammo");
-	
+
 	this.maxQuantity = 100;
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_GatlingAmmo.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_GatlingAmmo.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_gatlingammo
 @$scripts                              = MaterialStandard.as;
 										 MaterialMerge.as;
                                          Material_GatlingAmmo.as;
+										 DecayQuantity.as;
 										 MarkForPickup_Builder;
 										 MarkForPickup_Archer;
 										 MarkForPickup_Knight;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_PistolAmmo.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_PistolAmmo.as
@@ -1,5 +1,9 @@
 void onInit(CBlob@ this)
-{	
+{
+	if (isServer())
+	{
+		this.set_u8('decay step', 7);
+	}
 	this.Tag("ammo");
 
 	this.maxQuantity = 40;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_PistolAmmo.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_PistolAmmo.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_pistolammo
 @$scripts                              = MaterialStandard.as;
 										 MaterialMerge.as;
                                          Material_PistolAmmo.as;
+										 DecayQuantity.as;
 										 MarkForPickup_Builder;
 										 MarkForPickup_Archer;
 										 MarkForPickup_Knight;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_RifleAmmo.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_RifleAmmo.as
@@ -1,5 +1,9 @@
 void onInit(CBlob@ this)
-{	
+{
+	if (isServer())
+	{
+		this.set_u8('decay step', 7);
+	}
 	this.Tag("ammo");
 
 	this.maxQuantity = 30;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_RifleAmmo.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_RifleAmmo.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_rifleammo
 @$scripts                              = MaterialStandard.as;
 										 MaterialMerge.as;
                                          Material_RifleAmmo.as;
+										 DecayQuantity.as;
 										 MarkForPickup_Builder;
 										 MarkForPickup_Archer;
 										 MarkForPickup_Knight;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_ShotgunAmmo.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_ShotgunAmmo.as
@@ -1,5 +1,9 @@
 void onInit(CBlob@ this)
-{	
+{
+	if (isServer())
+	{
+		this.set_u8('decay step', 7);
+	}
 	this.Tag("ammo");
 
 	this.maxQuantity = 20;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_ShotgunAmmo.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Ammunition/Material_ShotgunAmmo.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_shotgunammo
 @$scripts                              = MaterialStandard.as;
 										 MaterialMerge.as;
                                          Material_ShotgunAmmo.as;
+										 DecayQuantity.as;
 										 MarkForPickup_Builder;
 										 MarkForPickup_Archer;
 										 MarkForPickup_Knight;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/MaterialStone.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/MaterialStone.cfg
@@ -60,7 +60,7 @@ $name                                  = mat_stone
 @$scripts                              = MaterialStone.as;
                                          MaterialStandard.as;
                                          MaterialMerge.as;
-                                         #DecayQuantity.as;
+                                         DecayQuantity.as;
                                          IgnoreDamage.as;
 										 MarkForPickup_Builder;
 f32_health                             = 1.0

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/MaterialWood.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/MaterialWood.as
@@ -3,7 +3,7 @@ void onInit(CBlob@ this)
 {
 	if (isServer())
 	{
-		this.set_u8('decay step', 18);
+		this.set_u8('decay step', 36);
 	}
 
 	this.maxQuantity = 500;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/MaterialWood.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/MaterialWood.cfg
@@ -60,7 +60,7 @@ $name                                  = mat_wood
 @$scripts                              = MaterialWood.as;
                                          MaterialStandard.as;
                                          MaterialMerge.as;
-                                         #DecayQuantity.as;
+                                         DecayQuantity.as;
                                          IgnoreDamage.as;
 										 MarkForPickup_Builder;
 f32_health                             = 1.0

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/Material_Ganja.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/Material_Ganja.cfg
@@ -72,6 +72,7 @@ $name                                  = mat_ganja
                                          MaterialMerge.as;
 										 Material_Protopopov.as;
 										 IgnoreDamage.as; 
+										 DecayQuantity.as;
 										 MarkForPickup_Builder;
 f32_health                             = 1.0
 # looks & behaviour inside inventory

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/Material_Meat.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/Material_Meat.as
@@ -1,5 +1,10 @@
 void onInit(CBlob@ this)
-{	
+{
+	if (isServer())
+	{
+		this.set_u8('decay step', 36);
+	}
+
 	this.maxQuantity = 250;
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/Material_Meat.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Construction/Material_Meat.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_meat
 @$scripts                              = MaterialStandard.as;
                                          MaterialMerge.as;
 										 Material_Meat.as;
+										 DecayQuantity.as;
 										 IgnoreDamage.as; 
 										 MarkForPickup_Builder;
 f32_health                             = 1.0

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_Ingot.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_Ingot.as
@@ -1,5 +1,13 @@
 void onInit(CBlob@ this)
-{	
+{
+	if (this.getName() == "mat_ironingot")
+	{
+		if (isServer())
+		{
+			this.set_u8('decay step', 2);
+		}
+	}
+
 	this.maxQuantity = 50;
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_IronIngot.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_IronIngot.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_ironingot
 @$scripts                              = MaterialStandard.as;
                                          MaterialMerge.as;
 										 Material_Ingot.as;
+										 DecayQuantity.as;
 										 IgnoreDamage.as; 
 										 MarkForPickup_Builder;
 f32_health                             = 1.0

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Coal.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Coal.as
@@ -1,5 +1,10 @@
 void onInit(CBlob@ this)
 {
+	if (isServer())
+	{
+		this.set_u8('decay step', 6);
+	}
+
 	this.maxQuantity = 50;
 	this.set_u8("fuel_energy", 20);
 

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Coal.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Coal.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_coal
 @$scripts                              = MaterialStandard.as;
                                          MaterialMerge.as;
 										 Material_Coal.as;
+										 DecayQuantity.as;
 										 IgnoreDamage.as; 
 										 MarkForPickup_Builder;
 f32_health                             = 1.0

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Dirt.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Dirt.as
@@ -1,5 +1,10 @@
 void onInit(CBlob@ this)
-{	
+{
+	if (isServer())
+	{
+		this.set_u8('decay step', 30);
+	}
+
 	this.maxQuantity = 500;
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Dirt.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Dirt.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_dirt
 @$scripts                              = MaterialStandard.as;
                                          MaterialMerge.as;
 										 Material_Dirt.as;
+										 DecayQuantity.as;
 										 IgnoreDamage.as; 
 										 MarkForPickup_Builder;
 f32_health                             = 1.0

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Iron.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Iron.as
@@ -1,5 +1,10 @@
 void onInit(CBlob@ this)
-{	
+{
+	if (isServer())
+	{
+		this.set_u8('decay step', 5);
+	}
+
 	this.maxQuantity = 500;
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Iron.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Iron.cfg
@@ -71,6 +71,7 @@ $name                                  = mat_iron
 @$scripts                              = MaterialStandard.as;
                                          MaterialMerge.as;
 										 Material_Iron.as;
+										 DecayQuantity.as;
 										 IgnoreDamage.as; 
 										 MarkForPickup_Builder;
 f32_health                             = 1.0

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Protopopov.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Protopopov.as
@@ -1,5 +1,10 @@
 void onInit(CBlob@ this)
-{	
+{
+	if (isServer())
+	{
+		this.set_u8('decay step', 34);
+	}
+
 	this.maxQuantity = 250;
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Protopopov.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Raw/Material_Protopopov.cfg
@@ -72,6 +72,7 @@ $name                                  = mat_protopopov
                                          MaterialMerge.as;
 										 Material_Protopopov.as;
 										 IgnoreDamage.as; 
+										 DecayQuantity.as;
 										 MarkForPickup_Builder;
 										 MarkForPickup_Knight;
 f32_health                             = 1.0


### PR DESCRIPTION
Several materials end up getting left on the floor unused and end up clogging people's inventories and litter the map.
- Adds decay over time to several materials, which includes wood, stone, dirt, meat, coal, iron ore, iron ingots, and all of the regular ammo types.

The decay times are not the same for each. Materials like meat will decay faster while iron ingots will decay slower. 
Decay rates are located in the commit descriptions.

If anyone wants any other material to decay, comment it below and it will be considered.