### PR TITLE
Big bomb return

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Explosives/Material_BigBomb.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Explosives/Material_BigBomb.as
@@ -12,7 +12,7 @@ void onInit(CBlob@ this)
 	this.getShape().SetRotationsAllowed(true);
 
 	this.set_string("custom_explosion_sound", "bigbomb_explosion.ogg");
-	this.set_f32("explosion_volume", 4.0f);
+	this.set_f32("explosion_volume", 3.0f);
 	this.set_bool("map_damage_raycast", true);
 	this.set_Vec2f("explosion_offset", Vec2f(0, 16));
 

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Explosives/Material_BigBomb.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Explosives/Material_BigBomb.as
@@ -10,18 +10,19 @@ string[] particles =
 void onInit(CBlob@ this)
 {
 	this.getShape().SetRotationsAllowed(true);
-	
+
 	this.set_string("custom_explosion_sound", "bigbomb_explosion.ogg");
+	this.set_f32("explosion_volume", 4.0f);
 	this.set_bool("map_damage_raycast", true);
-	this.set_Vec2f("explosion_offset", Vec2f(0, 32));
-	
+	this.set_Vec2f("explosion_offset", Vec2f(0, 16));
+
 	this.set_u8("stack size", 1);
 	this.set_f32("bomb angle", 90);
-	
+
 	this.Tag("map_damage_dirt");
 	this.Tag("explosive");
 	this.Tag("heavy weight");
-	
+
 	this.maxQuantity = 1;
 }
 
@@ -41,13 +42,13 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		this.set_f32("bomb angle", 90);
 		this.server_Die();
 	}
-	
+
 	return damage;
 }
 
 bool canBePutInInventory(CBlob@ this, CBlob@ inventoryBlob)
 {
-	if (inventoryBlob.hasTag("human"))
+	if (inventoryBlob.hasTag("human") || inventoryBlob.getName() == "backpackblob")
 	{
 		if (inventoryBlob.isMyPlayer()) Sound::Play("NoAmmo");
 		return false;
@@ -65,10 +66,10 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid, Vec2f normal)
 	f32 vellen = this.getOldVelocity().Length();
 	if (vellen >= 12.0f) 
 	{
-		Vec2f dir = Vec2f(-normal.x, normal.y);
-		
+		//Vec2f dir = Vec2f(-normal.x, normal.y);
+
 		this.Tag("DoExplode");
-		this.set_f32("bomb angle", dir.Angle());
+		//this.set_f32("bomb angle", dir.Angle());
 		this.server_Die();
 	}
 }
@@ -81,11 +82,11 @@ void DoExplosion(CBlob@ this)
 		addToNextTick(this, rules, DoExplosion);
 		return;
 	}
-	
-	// this.set_f32("map_damage_radius", 48.0f);
-	// this.set_f32("map_damage_ratio", 0.4f);
-	// f32 angle = this.get_f32("bomb angle");
-	
+
+	this.set_f32("map_damage_radius", 48.0f);
+	this.set_f32("map_damage_ratio", 0.4f);
+	f32 angle = this.getAngleDegrees() - this.get_f32("bomb angle");
+
 	if (isServer())
 	{
 		CBlob@ boom = server_CreateBlobNoInit("nukeexplosion");
@@ -93,34 +94,37 @@ void DoExplosion(CBlob@ this)
 		{
 			boom.setPosition(this.getPosition());
 			boom.set_u8("boom_start", 0);
-			boom.set_u8("boom_end", 8);
+			boom.set_u8("boom_end", 4);
 			boom.set_u8("boom_frequency", 1);
 			boom.set_u32("boom_delay", 0);
 			boom.set_u32("flash_delay", 0);
+			boom.set_string("custom_explosion_sound", "bigbomb_explosion.ogg");
 			boom.Tag("no fallout");
 			boom.Tag("no flash");
 			boom.Tag("no mithril");
+			boom.Tag("no side blast");
+			boom.Tag("no sound");
 			boom.Init();
 		}
 	}
-	
-	// Explode(this, 48.0f, 50.0f);
-	
-	// for (int i = 0; i < 4; i++) 
-	// {
-		// Vec2f dir = getRandomVelocity(angle, 1, 40);
-		// LinearExplosion(this, dir, 40.0f + XORRandom(64), 48.0f, 6, 0.5f, Hitters::explosion);
-	// }
+
+	Explode(this, 50.0f + XORRandom(10), 15.0f);
+
+	for (int i = 0; i < 4; i++) 
+	{
+		Vec2f dir = getRandomVelocity(angle, 1, 40);
+		LinearExplosion(this, dir, 8.0f + XORRandom(16), 8 + XORRandom(24), 3, 0.125f, Hitters::explosion);
+	}
 	if(!isClient()){return;}
-	f32 angle = this.get_f32("bomb angle");
+
 	Vec2f pos = this.getPosition();
 	CMap@ map = getMap();
-	
+
 	for (int i = 0; i < 80; i++)
 	{
 		MakeParticle(this, Vec2f( XORRandom(128) - 64, XORRandom(100) - 50), getRandomVelocity(angle, XORRandom(350) * 0.01f, 90), particles[XORRandom(particles.length)]);
 	}
-	
+
 	this.getSprite().Gib();
 }
 

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Explosion.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Explosion.as
@@ -65,7 +65,7 @@ void Explode(CBlob@ this, f32 radius, f32 damage)
 	//
 	// shouldExplode sits in BTL_Include.as
 	//
-	
+
 	CRules@ rules = getRules();
 	if (!shouldExplode(this, rules))
 	{
@@ -79,13 +79,14 @@ void Explode(CBlob@ this, f32 radius, f32 damage)
 
 	if(isClient())
 	{
+		if (!this.exists("explosion_volume")) this.set_f32("explosion_volume", 1.0f);
 		if (!this.exists("custom_explosion_sound"))
 		{
 			Sound::Play("Bomb.ogg", this.getPosition());
 		}
 		else if (this.get_string("custom_explosion_sound") != "")
 		{
-			Sound::Play(this.get_string("custom_explosion_sound"), this.getPosition());
+			Sound::Play(this.get_string("custom_explosion_sound"), this.getPosition(), this.get_f32("explosion_volume"));
 		}
 	}
 
@@ -137,11 +138,11 @@ void Explode(CBlob@ this, f32 radius, f32 damage)
 
 	const bool should_teamkill = this.exists("explosive_teamkill") && this.get_bool("explosive_teamkill");
 	const bool damage_dirt = this.hasTag("map_damage_dirt");
-	
+
 	const int r = (radius * (2.0 / 3.0));
-	
+
 	const bool hitmap = this.hasTag("use hitmap");
-	
+
 	if (hitter == Hitters::water)
 	{
 		int tilesr = (r / map.tilesize) * 0.5f;
@@ -192,7 +193,7 @@ void Explode(CBlob@ this, f32 radius, f32 damage)
 		m_pos.x = Maths::Floor(m_pos.x);
 		m_pos.y = Maths::Floor(m_pos.y);
 		m_pos = (m_pos * map.tilesize) + Vec2f(map.tilesize / 2, map.tilesize / 2);
-		
+
 		//explode outwards
 		for (int x_step = 0; x_step <= tile_rad; ++x_step)
 		{
@@ -380,7 +381,7 @@ void LinearExplosion(CBlob@ this, Vec2f _direction, f32 length, const f32 width,
 							if (!justhurt) damaged = true;
 
 							justhurt = justhurt || !(this.hasTag("map_damage_dirt") ? true : canExplosionDestroy(this, map, tpos, t));
-							
+
 							if (hitmap) this.server_HitMap(tpos, Vec2f(0, 0), justhurt ? 5.0f : 100.0f, Hitters::explosion);
 							else map.server_DestroyTile(tpos, justhurt ? 5.0f : 100.0f, this);
 						}
@@ -440,7 +441,6 @@ void LinearExplosion(CBlob@ this, Vec2f _direction, f32 length, const f32 width,
 	{
 		CBlob@ hit_blob = blobs[i];
 		if (hit_blob is null || hit_blob is this) { continue; }
-	
 
 		float rad = Maths::Max(tilesize, hit_blob.getRadius() * 0.25f);
 		Vec2f hit_blob_pos = hit_blob.getPosition();
@@ -566,9 +566,9 @@ bool HitBlob(CBlob@ this, CBlob@ hit_blob, f32 radius, f32 damage, const u8 hitt
 	{
 		makeSmallExplosionParticle(hit_blob_pos);
 	}
-	
+
 	// hit_blob.AddForce(bombforce * hit_blob.getRadius());
-	
+
 	return true;
 }
 
@@ -583,7 +583,7 @@ void WorldExplode(Vec2f position, f32 radius, f32 damage, const string explosion
 	f32 map_damage_ratio = 0.5f;
 	bool map_damage_raycast = true;
 	u8 hitter = Hitters::explosion;
-	
+
 	bool should_teamkill = true;
 
 	const int r = (radius * (2.0 / 3.0));
@@ -593,7 +593,7 @@ void WorldExplode(Vec2f position, f32 radius, f32 damage, const string explosion
 	makeLargeExplosionParticle(pos);
 
 	Sound::Play(explosionSound, pos);
-	
+
 	for (int i = 0; i < radius * 0.16; i++)
 	{
 		Vec2f partpos = pos + Vec2f(XORRandom(r * 2) - r, XORRandom(r * 2) - r);
@@ -669,13 +669,13 @@ void WorldExplode(Vec2f position, f32 radius, f32 damage, const string explosion
 								Vec2f tpos = m_pos + offset;
 
 								TileType tile = map.getTile(tpos).type;
-								
+
 								// if (!map.isTileBedrock(tile) && map.getTileNoise(map.getTileOffset(tpos)) != 241)
 								if (!map.isTileBedrock(tile))
 								{
 									if (dist >= rad_thresh || map.isTileGroundStuff(tile)) //  !canExplosionDestroy(this, map, tpos, tile)) // (this.hasTag("map_damage_dirt") ? true : !canExplosionDestroy(this, map, tpos, t))
 									{
-										map.server_DestroyTile(tpos, 1.0f);			
+										map.server_DestroyTile(tpos, 1.0f);
 									}
 									else
 									{
@@ -719,6 +719,6 @@ bool WorldHitBlob(Vec2f position, CBlob@ hit_blob, f32 radius, f32 damage, const
 	{
 		hit_blob.server_Hit(hit_blob, hit_blob_pos, Vec2f(), dam, hitter, true);
 	}
-	
+
 	return true;
 }

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/NukeExplosion/NukeExplosion.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/NukeExplosion/NukeExplosion.as
@@ -20,7 +20,7 @@ void onInit(CBlob@ this)
 	this.Tag("map_damage_dirt");
 	this.getShape().SetStatic(true);
 	this.set_f32("map_damage_ratio", 0.125f);
-	
+
 	if (!this.exists("boom_frequency")) this.set_u8("boom_frequency", 3);
 	if (!this.exists("boom_start")) this.set_u8("boom_start", 0);
 	if (!this.exists("boom_end")) this.set_u8("boom_end", 20);
@@ -29,7 +29,7 @@ void onInit(CBlob@ this)
 	if (!this.exists("mithril_amount")) this.set_f32("mithril_amount", 150);
 	if (!this.exists("flash_distance")) this.set_f32("flash_distance", 2500);
 	if (!this.exists("custom_explosion_sound")) this.set_string("custom_explosion_sound", "Nuke_Kaboom");
-	
+
 	if (isClient())
 	{
 		Vec2f pos = getDriver().getWorldPosFromScreenPos(getDriver().getScreenCenterPos());
@@ -46,30 +46,33 @@ void DoExplosion(CBlob@ this)
 		addToNextTick(this, rules, DoExplosion);
 		return;
 	}
-	
+
 	ShakeScreen(512, 64, this.getPosition());
 	// SetScreenFlash(255 * (1.00f - (f32(this.get_u8("boom_start")) / f32(explosions_max))), 255, 255, 255);
-	
+
 	const f32 modifier = f32(this.get_u8("boom_start")) / f32(this.get_u8("boom_end"));
 	const f32 invModifier = 1.00f - modifier;
-	
+
 	this.set_f32("map_damage_radius", 256.0f * modifier);
-	
+
 	this.set_Vec2f("explosion_offset", Vec2f(0, 0));
 	Explode(this, 192.0f * modifier, 192.0f * (1.00f - modifier));
-	
-	for (int i = 0; i < 2; i++)
+
+	if (!this.hasTag("no side blast"))
 	{
-		this.set_Vec2f("explosion_offset", Vec2f((100 - XORRandom(200)) / 50.0f, (100 - XORRandom(200)) / 400.0f) * 128 * modifier);
-		Explode(this, 128.0f * modifier, 64.0f * (1 - modifier));
+		for (int i = 0; i < 2; i++)
+		{
+			this.set_Vec2f("explosion_offset", Vec2f((100 - XORRandom(200)) / 50.0f, (100 - XORRandom(200)) / 400.0f) * 128 * modifier);
+			Explode(this, 128.0f * modifier, 64.0f * (1 - modifier));
+		}
 	}
-	
+
 	if (isServer())
-	{	
+	{
 		if (!this.hasTag("no mithril"))
 		{
 			const f32 mithril_amount = this.get_f32("mithril_amount");
-			
+
 			for (int i = 0; i < 3; i++)
 			{
 				CBlob@ blob = server_CreateBlob("mat_mithril", this.getTeamNum(), this.getPosition());
@@ -77,35 +80,35 @@ void DoExplosion(CBlob@ this)
 				blob.setVelocity(Vec2f(30 - XORRandom(60), -10 - XORRandom(20)) * (0.5f + modifier));
 			}
 		}
-		
+
 		if (!this.hasTag("no fallout") && XORRandom(100) < 75 * (invModifier * invModifier))
 		{
 			CBlob@ blob = server_CreateBlob("falloutgas", this.getTeamNum(), this.getPosition());
 			// blob.setVelocity(Vec2f(30 - XORRandom(120), -10 - XORRandom(20)) * (0.5f + modifier));
 			blob.setPosition(this.getPosition() + Vec2f(128 - XORRandom(256), 50 - XORRandom(100)) * (0.75f + modifier));
 		}
-		
+
 		if (!this.hasTag("no flash"))
-		{		
+		{
 			CMap@ map = this.getMap();
 			const f32 flash_distance = this.get_f32("flash_distance");
-		
+
 			for (int i = 0; i < 30; i++)
 			{
 				Vec2f dir = Vec2f(XORRandom(200) - 100, XORRandom(200) - 100);
 				dir.Normalize();
-				
+
 				Vec2f hit;
-				
+
 				if (map.rayCastSolidNoBlobs(this.getPosition(), this.getPosition() + (dir * flash_distance), hit))
 				{
 					Vec2f tp = hit + (dir * 0.25f);
-					
+
 					// if (map.isTileGrass(map.getTile(tp + Vec2f(0, -8)).type))
 					// {
 						// map.server_DestroyTile(tp + Vec2f(0, -8), 1.0f);
 					// }
-					
+
 					map.server_DestroyTile(tp, 1.0f);
 					map.server_setFireWorldspace(tp, true);
 				}
@@ -121,7 +124,7 @@ void DoExplosion(CBlob@ this)
 				const f32 flash_distance = this.get_f32("flash_distance");
 
 				// print("" + dist + " / " + flash_distance);
-				
+
 				if (dist <= flash_distance)
 				{
 					f32 flashMod = Maths::Sqrt(1.00f - (dist / flash_distance));
@@ -139,7 +142,7 @@ void DoExplosion(CBlob@ this)
 			{
 				Vec2f d = getRandomVelocity(90, XORRandom(50) * 0.01f, 25);
 				d.y *= 0.20f;
-				
+
 				MakeParticle(this, Vec2f((XORRandom(60) - 30) * modifier * 20.00f, (XORRandom(40) - 20) * invModifier * 8.00f), d, XORRandom(8) + 10 * invModifier, particles[XORRandom(particles.length)]);
 				MakeParticle(this, Vec2f((XORRandom(40) - 20) * modifier * 12.00f, (XORRandom(30) - 15) * invModifier * 4.00f), d, XORRandom(20) + 20 * invModifier, particles[0]);
 			}
@@ -153,14 +156,14 @@ void onTick(CBlob@ this)
 	{
 		if (isServer()) this.server_Die();
 		this.Tag("dead");
-		
+
 		return;
 	}
-	
+
 	if (this.hasTag("dead")) return;
 
 	u32 ticks = this.getTickSinceCreated();
-	
+
 	if (isClient() && !this.hasTag("no flash") && ticks == this.get_u32("flash_delay")) 
 	{
 		CBlob@ localBlob = getLocalPlayerBlob();
@@ -176,54 +179,54 @@ void onTick(CBlob@ this)
 			}
 		}
 	}
-	
+
 	if (ticks >= this.get_u32("boom_delay") && ticks % this.get_u8("boom_frequency") == 0 && this.get_u8("boom_start") < this.get_u8("boom_end"))
 	{
 		DoExplosion(this);
 		this.set_u8("boom_start", this.get_u8("boom_start") + 1);
-		
+
 		// f32 modifier = 1.00f - (float(this.get_u8("boom_start")) / float(this.get_u8("boom_end")));
 		// this.SetLightRadius(1024.5f * modifier);
 	}
-	
+
 	if (!this.hasTag("no flash"))
 	{
 		if (isServer())
 		{
 			if (ticks == 2)
-			{		
+			{
 				CBlob@[] blobs;
-			
+
 				if (this.getMap().getBlobsInRadius(this.getPosition(), this.get_f32("flash_distance"), @blobs))
 				{
 					// print("" + blobs.length);
-				
+
 					for (int i = 0; i < blobs.length; i++)
 					{
 						CBlob@ blob = blobs[i];
-						
+
 						if (!this.getMap().rayCastSolidNoBlobs(blob.getPosition(), this.getPosition()))
 						{
 							this.server_Hit(blob, blob.getPosition(), Vec2f(), 350.00f, Hitters::fire, true);
 						}
 					}
 				}
-			}	
+			}
 		}
 	}
-		
+
 	if (isClient())
 	{
 		if (ticks > (sound_delay * 30) && !this.hasTag("sound_played"))
 		{
 			this.Tag("sound_played");
-		
+
 			f32 modifier = 1.00f - (sound_delay / 3.0f);
 			// print("modifier: " + modifier);
 			
-			if (modifier > 0.01f)
-			{	
-				Sound::Play("Nuke_Kaboom_Big.ogg", getDriver().getWorldPosFromScreenPos(getDriver().getScreenCenterPos()), 2.0f - (0.2f * (1 - modifier)), modifier);
+			if (modifier > 0.01f && !this.hasTag("no_sound"))
+			{
+				Sound::Play(this.get_string("custom_explosion_sound"), getDriver().getWorldPosFromScreenPos(getDriver().getScreenCenterPos()), 2.0f - (0.2f * (1 - modifier)), modifier);
 			}
 		}
 	}

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Cocok/AltarCocok.as
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Cocok/AltarCocok.as
@@ -57,9 +57,9 @@ void onInit(CBlob@ this)
 
 	AddIconToken("$icon_cocok_offering_2$", "AltarCocok_Icons.png", Vec2f(24, 24), 2);
 	{
-		ShopItem@ s = addShopItem(this, "Offering of Bomba", "$icon_cocok_offering_2$", "offering_bomb", "Sacrifice your dignity to weld a L.O.L. and some Explodium together.");
+		ShopItem@ s = addShopItem(this, "Offering of Bomba", "$icon_cocok_offering_2$", "offering_bomb", "Sacrifice your dignity to weld a L.O.L. and a big bomb together.");
 		AddRequirement(s.requirements, "blob", "mat_mininuke", "L.O.L.", 1);
-		AddRequirement(s.requirements, "blob", "mat_explodium", "Explodium.", 1);
+		AddRequirement(s.requirements, "blob", "mat_bigbomb", "Big Bomb", 1);
 		AddRequirement(s.requirements, "blob", "mat_mithrilenriched", "Enriched Mithril", 20);
 		s.customButton = true;
 		s.buttonwidth = 1;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/BombShop/BombShop.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/BombShop/BombShop.as
@@ -51,17 +51,17 @@ void onInit(CBlob@ this)
 
 		s.spawnNothing = true;
 	}
+	{
+		ShopItem@ s = addShopItem(this, "Big Bomb (1)", "$icon_bigbomb$", "mat_bigbomb-1", "A really big bomb. Handle with care. It's indeed a large bomb.");
+		AddRequirement(s.requirements, "coin", "", "Coins", 700);
+		AddRequirement(s.requirements, "blob", "mat_sulphur", "Sulphur", 150);
+		AddRequirement(s.requirements, "blob", "mat_coal", "Coal", 50);
+		s.customButton = true;
+		s.buttonwidth = 1;
+		s.buttonheight = 2;
 
-	// {
-		// ShopItem@ s = addShopItem(this, "S.Y.L.W. 9000 (1)", "$icon_bigbomb$", "mat_bigbomb-1", "A really big bomb. Handle with care. It's indeed a large bomb.");
-		// AddRequirement(s.requirements, "coin", "", "Coins", 1250);
-		// AddRequirement(s.requirements, "blob", "mat_sulphur", "Sulphur", 250);
-		// s.customButton = true;
-		// s.buttonwidth = 1;
-		// s.buttonheight = 2;
-
-		// s.spawnNothing = true;
-	// }
+		s.spawnNothing = true;
+	}
 	{
 		ShopItem@ s = addShopItem(this, "R.O.F.L.", "$icon_nuke$", "nuke", "A dangerous warhead stuffed in a cart. Since it's heavy, it can be only pushed around or picked up by balloons.");
 		AddRequirement(s.requirements, "blob", "mat_mithrilingot", "Mithril Ingot", 10);
@@ -100,7 +100,7 @@ void onInit(CBlob@ this)
 	{
 		ShopItem@ s = addShopItem(this, "Bunker Buster (1)", "$icon_bunkerbuster$", "mat_bunkerbuster-1", "Perfect for making holes in heavily fortified bases. Detonates upon strong impact.");
 		AddRequirement(s.requirements, "coin", "", "Coins", 100);
-		AddRequirement(s.requirements, "blob", "mat_sulphur", "Sulphur", 25);
+		AddRequirement(s.requirements, "blob", "mat_sulphur", "Sulphur", 50);
 
 		s.spawnNothing = true;
 	}


### PR DESCRIPTION
- Big bomb map damage reduced to about 1/4 of last power.
- Sound changes for the big bomb.
- Big bomb added back to the bomb shop.
- Big bomb replaces the explodium requirement in the cocok altar.
- Big bomb can't go inside backpacks anymore.

When thrown at dirt-

https://user-images.githubusercontent.com/68350259/113790414-8d374000-96fe-11eb-9cae-074b4742e75d.mp4

When thrown at building-

https://user-images.githubusercontent.com/68350259/113790436-9aecc580-96fe-11eb-8866-6374c1f44af5.mp4

The damage dealt-

https://user-images.githubusercontent.com/68350259/113790486-b1931c80-96fe-11eb-8a1e-56b8e0bb87de.mp4