### PR TITLE
Spawning & traveling

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/CombatChickens/CombatChicken.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/CombatChickens/CombatChicken.as
@@ -32,12 +32,14 @@ void onInit(CBlob@ this)
 {
 	Random@ rand = Random(this.getNetworkID());
 	string name = firstnames[rand.NextRanged(firstnames.length)] + " " + surnames[rand.NextRanged(surnames.length)];
-	
+
 	this.set_f32("gib health", -1.50f);
 	if (!this.exists("voice pitch")) this.set_f32("voice pitch", 1.50f);
 	this.set_string("chicken name", name);
 	this.setInventoryName(name);
-	
+
+	if (this.hasTag("parachute")) this.AddScript("parachutepack_effect.as");
+
 	this.Tag("dangerous");
 	this.Tag("chicken");
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/CommonCapturable.as
@@ -17,16 +17,16 @@ void onInit(CBlob@ this)
 {
 	this.addCommandID("convert");
 	this.getCurrentScript().tickFrequency = 30;
-	
+
 	// f32 capture_modifier = this.exists("capture_speed_modifier") ? this.get_f32("capture_speed_modifier") : 1.00f;
 	// u32 capture_seconds = this.getInitialHealth() * capture_modifier;
-	
+
 	this.set_s16(counter_prop, getCaptureSeconds(this));
 	this.set_s16(friendly_prop, 0);
 	this.set_s16(enemy_prop, 0);
-	
+
 	this.set_u16("last_friendly_visit",getGameTime());
-	
+
 	this.Tag("capturable");
 }
 
@@ -77,7 +77,7 @@ void onTick(CBlob@ this)
 					{
 						attackersCount++;
 						attackerTeam = b.getTeamNum();
-						
+
 						if (b.hasTag("combat chicken")) this.Tag(chicken_tag);
 					}
 				}
@@ -125,7 +125,7 @@ void onTick(CBlob@ this)
 					{
 						CBlob@ base = server_CreateBlob("chicken" + this.getName(), 250, this.getPosition());
 						base.server_SetHealth(this.getHealth());
-						
+
 						this.server_Die();
 					}
 				}
@@ -133,7 +133,7 @@ void onTick(CBlob@ this)
 				{
 					this.server_setTeamNum(attackerTeam < 8 ? attackerTeam : -1);
 				}
-			
+
 				reset_timer = true;
 			}
 			else
@@ -159,12 +159,12 @@ void onTick(CBlob@ this)
 		this.set_s16(enemy_prop, 0);
 
 		u32 capture_seconds = getCaptureSeconds(this);
-		
+
 		this.set_s16(counter_prop, capture_seconds);
 		this.Untag(raid_tag);
 		this.Untag(chicken_tag);
 		this.Tag(reinforcements_tag);
-		
+
 		sync = true;
 	}
 
@@ -175,8 +175,9 @@ void onTick(CBlob@ this)
 
 		this.Sync(counter_prop, true);
 		this.Sync(raid_tag, true);
+		this.Sync(reinforcements_tag, true);
 	}
-	
+
 	// if(!this.hasTag("faction_base"))
 	// if(this.get_u16("last_friendly_visit")+30*60*3 < getGameTime()){
 		// if(isServer()){
@@ -207,7 +208,6 @@ void onRender(CSprite@ this)
 	if (blob is null || !blob.hasTag(raid_tag))
 		return;
 
-	
 	Vec2f pos2d = getDriver().getScreenPosFromWorldPos(blob.getPosition() + Vec2f(0.0f, -blob.getHeight()));
 
 	s16 friendlyCount = blob.get_s16(friendly_prop);
@@ -230,10 +230,9 @@ void onRender(CSprite@ this)
 
 	u32 capture_seconds = getCaptureSeconds(blob);
 	if (capture_seconds <= 0) capture_seconds = 1; // ugly hackfix
-		
+
 	//draw capture bar
 	f32 padding = 4.0f;
 	s32 captureTime = blob.get_s16(counter_prop);
 	GUI::DrawProgressBar(Vec2f(pos2d.x - hwidth + padding, pos2d.y + hheight - 18 - padding), Vec2f(pos2d.x + hwidth - padding, pos2d.y + hheight - padding), 1.0f - float(captureTime) / float(capture_seconds));
-
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
@@ -335,17 +335,23 @@ void onTick(CRules@ this)
 				{
 					CBlob@[] bases;
 					getBlobsByTag("faction_base", @bases);
-					getBlobsByTag("respawn", @bases);
+					//getBlobsByTag("respawn", @bases);
 					CBlob@[] spawns;
+					int teamBases = 0;
 					bool has_bases = false;
+
+					for (uint i = 0; i < bases.length; i++)
+					{
+						if (bases[i].getTeamNum() == team) teamBases++;
+					}
+
 					for (uint i = 0; i < bases.length; i++)
 					{
 						CBlob@ base = bases[i];
 						if (base !is null && base.getTeamNum() == team)
 						{
 							has_bases = true;
-							if (!base.hasTag("reinforcements allowed")) continue;
-							spawns.push_back(bases[i]);
+							if (base.hasTag("reinforcements allowed") || teamBases == 1) spawns.push_back(base);
 						}
 					}
 
@@ -371,15 +377,10 @@ void onTick(CRules@ this)
 							}
 						}
 
-						string blobType=player.get_string("classAtDeath");
-						if(blobType=="royalguard")
-						{
-							blobType="knight";
-						}
-						if(blobType!="builder" && blobType!="knight" && blobType!="archer" && blobType!="sapper")
-						{
-							blobType="builder";
-						}
+						string blobType = player.get_string("classAtDeath");
+						if (blobType == "builder" || blobType == "engineer" || blobType == "hazmat" || blobType == "slave" || blobType == "peasant") blobType = "builder";
+						else if (blobType == "archer") blobType = "archer";
+						else blobType = "knight";
 
 						CBlob@ new_blob = server_CreateBlob(blobType);
 
@@ -507,7 +508,6 @@ void onInit(CRules@ this)
 	CSecurity@ sec = getSecurity();
 	sec.unBan("TFlippy");
 
-
 	// Print out a message to anybody running TC server/localhost
 	if (isServer() && !isClient())
 	{
@@ -598,24 +598,28 @@ bool doChickenSpawn(CPlayer@ player)
 	getBlobsByName("chickenconvent", @ruins);
 	getBlobsByName("chickencoop", @ruins);
 
-	if (ruins.length > 0)
+	CBlob@[] bases;
+	getBlobsByName("fortress", @bases);
+	getBlobsByName("stronghold", @bases);
+	getBlobsByName("citadel", @bases);
+	getBlobsByName("convent", @bases);
+
+	if (ruins.length > 0 || bases.length > 0)
 	{
 		string blobType;
 		int minutes = getGameTime() / (60*30);
 		int rand = XORRandom(100) - minutes;
+		if (rand < 5) rand = 4;
+
 		if (rand < 5)
 		{
-			rand = 4;
+			blobType = "commanderchicken";
 		}
-		if (rand < 5)
+		else if (rand < 15)
 		{
 			blobType = "heavychicken";
 		}
-		else if (rand < 25)
-		{
-			blobType = "commmanderchicken";
-		}
-		else if (rand < 50)
+		else if (rand < 45)
 		{
 			blobType = "soldierchicken";
 		}
@@ -628,13 +632,30 @@ bool doChickenSpawn(CPlayer@ player)
 
 		if (new_blob !is null)
 		{
-			CBlob@ r = ruins[XORRandom(ruins.length)];
+			if (ruins.length > 0)
+			{
+				CBlob@ r = ruins[XORRandom(ruins.length)];
 
-			new_blob.setPosition(r.getPosition());
-			new_blob.server_setTeamNum(250);
-			new_blob.server_SetPlayer(player);
+				new_blob.setPosition(r.getPosition());
+				new_blob.server_setTeamNum(250);
+				new_blob.server_SetPlayer(player);
 
-			return true;
+				return true;
+			}
+			else
+			{
+				//parachute chickens!
+				//bots will not parachute correctly on server, only localhost
+				CBlob@ b = bases[XORRandom(bases.length)];
+
+				new_blob.setPosition(Vec2f(b.getPosition().x + (200 - XORRandom(400)), 0.0f));
+				new_blob.server_setTeamNum(250);
+				new_blob.server_SetPlayer(player);
+				new_blob.Tag("parachute");
+				if (isClient()) new_blob.AddScript("parachutepack_effect.as"); //for localhost
+
+				return true;
+			}
 		}
 		else return false;
 	}
@@ -669,9 +690,6 @@ void Reset(CRules@ this)
 
 	server_CreateBlob("tc_soundscapes");
 }
-
-
-
 
 /*
 void SpawnEventFireworks()

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Equipment/ParachutePack/parachutepack_effect.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Equipment/ParachutePack/parachutepack_effect.as
@@ -5,7 +5,7 @@ void onInit(CBlob@ this)
 {
 	this.addCommandID("deploy_chute");
 
-	if(this.get_string("reload_script") != "parachutepack")
+	if (this.get_string("reload_script") != "parachutepack")
 	{
 		UpdateScript(this);
 	}
@@ -20,14 +20,13 @@ void UpdateScript(CBlob@ this)
 		pack.SetRelativeZ(-2);
 		pack.SetOffset(Vec2f(0, 0));
 
-		if(this.getSprite().isFacingLeft())
+		if (this.getSprite().isFacingLeft())
 		{
 			pack.SetFacingLeft(true);
 		}
 	}
 
-	int teamnum = this.getTeamNum();
-	CSpriteLayer@ parachute = this.getSprite().addSpriteLayer("parachute", "parachutepack", 32, 32, teamnum, 0);
+	CSpriteLayer@ parachute = this.getSprite().addSpriteLayer("parachute", "parachutepack", 32, 32);
 	if (parachute !is null)
 	{
 		Animation@ anim = parachute.addAnimation("default", 0, true);
@@ -65,7 +64,7 @@ void onTick(CBlob@ this)
 	bool candeploy = (this.isOnGround() || this.isInWater() || this.isAttached() || this.isOnLadder());
 	bool deployavailable = getGameTime() >= this.get_u32("next use");
 
-	if(this.get_string("reload_script") == "parachutepack")
+	if (this.get_string("reload_script") == "parachutepack")
 	{
 		UpdateScript(this);
 		this.set_string("reload_script", "");
@@ -110,6 +109,9 @@ void onTick(CBlob@ this)
 		if (candeploy)
 		{
 			HideParachute(this);
+
+			//chicken parachute is temporary
+			if (this.hasTag("chicken")) this.RemoveScript("parachutepack_effect.as");
 		}
 	}
 }

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/CommonFactionBuilding.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/CommonFactionBuilding.as
@@ -239,7 +239,6 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 				bool upkeep_gud = (team_data.upkeep + UPKEEP_COST_PLAYER) <= team_data.upkeep_cap;
 				bool is_premium = true; //ply.getSupportTier() > 0; // TODO
 
-				print("" + ply.getSupportTier());
 				//print("" + ply.getSupportTier());
 
 				bool can_join = recruitment_enabled && upkeep_gud && is_premium;
@@ -325,6 +324,7 @@ void Faction_Menu(CBlob@ this, CBlob@ caller)
 		{
 			int fortTeamNum = forts[i].getTeamNum();
 			if (fortTeamNum == this.getTeamNum()) teamForts++;
+		}
 		const bool canDestroy = teamForts != 1;
 
 		{

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/CommonFactionBuilding.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/CommonFactionBuilding.as
@@ -240,6 +240,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 				bool is_premium = true; //ply.getSupportTier() > 0; // TODO
 
 				print("" + ply.getSupportTier());
+				//print("" + ply.getSupportTier());
 
 				bool can_join = recruitment_enabled && upkeep_gud && is_premium;
 
@@ -315,6 +316,16 @@ void Faction_Menu(CBlob@ this, CBlob@ caller)
 
 		const bool base_demolition = this.get_bool("base_demolition");
 		const bool base_alarm = this.get_bool("base_alarm");
+
+		CBlob@[] forts;
+		getBlobsByTag("faction_base", @forts);
+		int teamForts = 0;
+
+		for(uint i = 0; i < forts.length; i++)
+		{
+			int fortTeamNum = forts[i].getTeamNum();
+			if (fortTeamNum == this.getTeamNum()) teamForts++;
+		const bool canDestroy = teamForts != 1;
 
 		{
 			CGridMenu@ menu = CreateGridMenu(getDriver().getScreenCenterPos() + Vec2f(0.0f, 0.0f), this, Vec2f(3, 3), "Faction Policies");
@@ -411,7 +422,7 @@ void Faction_Menu(CBlob@ this, CBlob@ caller)
 
 					CGridButton@ butt = menu.AddButton("$faction_remove$", (base_demolition ? "Cancel" : "Commence") + " demolition of this building", this.getCommandID("faction_menu_button"), Vec2f(1, 1), params);
 					butt.hoverText = (base_demolition ? "Cancels" : "Commences") + " demolition of this building, destroying it over course of several seconds.";
-					butt.SetEnabled(isLeader);
+					butt.SetEnabled(isLeader && !this.hasTag("under raid") && canDestroy);
 				}
 				{
 					CBitStream params;
@@ -837,7 +848,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ inParams)
 				string oldTeamName = rules.getTeam(oldTeam).getName();
 				string newTeamName = rules.getTeam(newTeam).getName();
 
-				client_AddToChat(oldTeamName + "'s "+this.getInventoryName()+" has captured by the " + newTeamName + "!", SColor(0xff444444));
+				client_AddToChat(oldTeamName + "'s "+this.getInventoryName()+" has been captured by the " + newTeamName + "!", SColor(0xff444444));
 				if (defeat)
 				{
 					client_AddToChat(oldTeamName + " has been defeated by the " + newTeamName + "!", SColor(0xff444444));


### PR DESCRIPTION
Set on improving the general systems of faction war.
This is a very plausible solution for issue #141 and is likely connected with some other issues as well.

**Spawning**
- Players will not spawn at bases being attacked, unless there is only one base or if the bases are contested.
- When spawning as a chicken there is now a chance to become a chicken commander.
- If all spawns on the map are blocked for neutrals, then the players will spawn as chickens with parachutes, and be parachuted onto faction bases. :parachute:

**Travel**
- Coalmines/bases cannot be traveled to if they are being captured, unless contested.
- Areas being attacked will indicate if they are contested or not in the travel menu.

**Faction destruction**
- Bases cannot be destroyed by the owner if the base is being attacked.
- If there is only one base for a team, it cannot be destroyed by the owner.

Questions or concerns about these proposals? Comment below.