### PR TITLE
Mason altar bug fixed

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BlockPlacement.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BlockPlacement.as
@@ -39,7 +39,7 @@ void PlaceBlock(CBlob@ this, u8 index, Vec2f cursorPos)
 					else
 					{
 						altar.add_f32("deity_power", 1);
-						if (isServer()) this.Sync("deity_power", false);
+						if (isServer()) altar.Sync("deity_power", false);
 					}
 				}
 			}


### PR DESCRIPTION
Now actually gains 1 power from its followers placing stuff, this was already in the code but was not working since it wasn't syncing correctly. Fun fact when testing this with a local server it will actually work which is probably why this wasn't found previously.

(Each 1 power increases the chance by 0.01%, only gains the power when the block wasn't free)