### PR TITLE
75% Mason Altar Free Block Cap

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BlockPlacement.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BlockPlacement.as
@@ -30,8 +30,8 @@ void PlaceBlock(CBlob@ this, u8 index, Vec2f cursorPos)
 				CBlob@ altar = getBlobByName("altar_mason");
 				if (altar !is null)
 				{
-					// print("free block chance: " + altar.get_f32("deity_power") * 0.01f);
-					if (XORRandom(100) < altar.get_f32("deity_power") * 0.01f)
+					print("free block chance: " + Maths::Min((altar.get_f32("deity_power") * 0.01f),MAX_FREE_BLOCK_CHANCE));
+					if (XORRandom(100) < Maths::Min((altar.get_f32("deity_power") * 0.01f),MAX_FREE_BLOCK_CHANCE))
 					{
 						take = false;
 						// print("free block!");		

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BlockPlacement.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BlockPlacement.as
@@ -30,7 +30,7 @@ void PlaceBlock(CBlob@ this, u8 index, Vec2f cursorPos)
 				CBlob@ altar = getBlobByName("altar_mason");
 				if (altar !is null)
 				{
-					print("free block chance: " + Maths::Min((altar.get_f32("deity_power") * 0.01f),MAX_FREE_BLOCK_CHANCE));
+					//print("free block chance: " + Maths::Min((altar.get_f32("deity_power") * 0.01f),MAX_FREE_BLOCK_CHANCE));
 					if (XORRandom(100) < Maths::Min((altar.get_f32("deity_power") * 0.01f),MAX_FREE_BLOCK_CHANCE))
 					{
 						take = false;

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/DeityCommon.as
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/DeityCommon.as
@@ -13,3 +13,5 @@ namespace Deity
 		foghorn
 	}
 }
+
+const f32 MAX_FREE_BLOCK_CHANCE = 75.0f;

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mason/AltarMason.as
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mason/AltarMason.as
@@ -11,6 +11,8 @@ void onInit(CBlob@ this)
 	this.SetLight(true);
 	this.SetLightRadius(64.0f);
 	this.SetLightColor(SColor(255, 255, 180, 0));
+
+	//this.set_f32("deity_power",10000); //for testing if the cap is actually working
 	
 	CSprite@ sprite = this.getSprite();
 	sprite.SetEmitSound("Disc_MountainKing.ogg");
@@ -36,7 +38,7 @@ void onTick(CSprite@ this)
 	if (blob is null) return;
 
 	const f32 power = blob.get_f32("deity_power");
-	blob.setInventoryName("Altar of Grand Mason\n\nMasonic Power: " + power + "\nFree block chance: " + (power * 0.01f) + "%");
+	blob.setInventoryName("Altar of Grand Mason\n\nMasonic Power: " + power + "\nFree block chance: " + Maths::Min((power * 0.01f),MAX_FREE_BLOCK_CHANCE) + "%");
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)


### PR DESCRIPTION
Caps the chance for free blocks at 75%, this is done via a constant which can be changed easily. Does not cap how much power the altar can hold for future altar abilities