### PR TITLE
Vehicle Gyromats

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/BomberCommon.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/BomberCommon.as
@@ -318,6 +318,12 @@ void BomberHandling(CBlob@ this,VehicleInfo@ v)
 				force.x*=1.1f;
 			}
 		}
+
+		if(this.exists("gyromat_acceleration"))
+		{
+			force.x *= Maths::Sqrt(this.get_f32("gyromat_acceleration"));
+		}
+				
 		this.AddForce(Vec2f(force.x * fuelModifier, -force.y * fuelModifier));
 	}
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/BomberCommon.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/BomberCommon.as
@@ -319,7 +319,7 @@ void BomberHandling(CBlob@ this,VehicleInfo@ v)
 			}
 		}
 
-		if(this.exists("gyromat_acceleration"))
+		if (this.exists("gyromat_acceleration"))
 		{
 			force.x *= Maths::Sqrt(this.get_f32("gyromat_acceleration"));
 		}

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/VehicleCommon.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/VehicleCommon.as
@@ -561,7 +561,7 @@ void Vehicle_StandardControls(CBlob@ this, VehicleInfo@ v)
 						}
 
 						// add gyromat effect
-						if(this.exists("gyromat_acceleration"))
+						if (this.exists("gyromat_acceleration"))
 						{
 							moveForce *= Maths::Sqrt(this.get_f32("gyromat_acceleration"));
 						}

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/VehicleCommon.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/VehicleCommon.as
@@ -560,6 +560,12 @@ void Vehicle_StandardControls(CBlob@ this, VehicleInfo@ v)
 							moveForce *= 1.5f;
 						}
 
+						// add gyromat effect
+						if(this.exists("gyromat_acceleration"))
+						{
+							moveForce *= Maths::Sqrt(this.get_f32("gyromat_acceleration"));
+						}
+
 						bool slopeangle = (angle > 15 && angle < 345 && this.isOnMap());
 
 						Vec2f pos = this.getPosition();
@@ -632,6 +638,7 @@ void Vehicle_StandardControls(CBlob@ this, VehicleInfo@ v)
 					const bool down = ap.isKeyPressed(key_down) || ap.isKeyPressed(key_action3);
 					if (onground && (down || moveUp))
 					{
+						//print("VEHICLE ON GROUND");
 						const bool faceleft = this.isFacingLeft();
 						if (angle > 330 || angle < 30)
 						{

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/ArmoredBomber/ArmoredBomber.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/ArmoredBomber/ArmoredBomber.cfg
@@ -121,7 +121,8 @@ $name                                      = armoredbomber
 										 CargoAttachment.as;
 										 VehicleConvert.as;
 										 VehicleAttachment.as;
-										 RunOverPeople.as;										 
+										 RunOverPeople.as;
+										 GyromatSupport.as
 f32 health                                 = 50.0
 # looks & behaviour inside inventory
 $inventory_name                            = Armored Bomber

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/ArmoredCar/AmoredCar.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/ArmoredCar/AmoredCar.cfg
@@ -91,6 +91,7 @@ $name                                      = armoredcar
 										VehicleConvert.as;
 										RunOverPeople.as;
 										DestructionAnimation.as;
+										GyromatSupport.as
 f32 health                                 = 40.0
 # looks & behaviour inside inventory
 $inventory_name                            = Armored Car

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Ballista/Ballista.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Ballista/Ballista.cfg
@@ -1,4 +1,4 @@
-# Boat config file
+# Catapult config file
 # $ string
 # @ array
 
@@ -10,31 +10,29 @@ $sprite_factory                            = generic_sprite
 											 VehicleGUI.as;
 											 Wooden.as;
 											 FireAnim.as;
-											 Bomber.as;
-											 BomberCommon.as;
 											 HealthBar.as;
 											 VehicleConvert.as;
-$sprite_texture                            = Balloon.png
-s32_sprite_frame_width                     = 48
-s32_sprite_frame_height                    = 16
+$sprite_texture                            = Ballista.png
+s32_sprite_frame_width                     = 40
+s32_sprite_frame_height                    = 40
 f32 sprite_offset_x                        = 0
-f32 sprite_offset_y                        = 8
+f32 sprite_offset_y                        = 0
 
 	$sprite_gibs_start                     = *start*
 
 	$gib_type                              = predefined
 	$gib_style                             = wooden
-	u8 gib_count                           = 12
+	u8 gib_count                           = 9
 	@u8 gib_frame                          = 4; 5; 6; 7;
-	f32 velocity                           = 12.0
+	f32 velocity                           = 10.0
 	f32 offset_x                           = -10.0
 	f32 offset_y                           = 0.0
 	
 	$gib_type                              = predefined
 	$gib_style                             = wooden
-	u8 gib_count                           = 6
+	u8 gib_count                           = 4
 	@u8 gib_frame                          = 0; 1; 2; 3;
-	f32 velocity                           = 9.0
+	f32 velocity                           = 7.0
 	f32 offset_x                           = 0.0
 	f32 offset_y                           = 0.0
 	
@@ -42,91 +40,91 @@ f32 sprite_offset_y                        = 8
 	$gib_style                             = wooden
 	u8 gib_count                           = 6
 	@u8 gib_frame                          = 4; 5; 6; 7;
-	f32 velocity                           = 16.0
+	f32 velocity                           = 10.0
 	f32 offset_x                           = 10.0
 	f32 offset_y                           = 0.0
 	
 	$sprite_gibs_end                       = *end*
-									 
+									  
   $sprite_animation_start                  = *start*
   
   # default
   $sprite_animation_default_name           = default
   u16 sprite_animation_default_time        = 0
   u8_sprite_animation_default_loop         = 0
-  @u16 sprite_animation_default_frames     = 1; 3;
+  @u16 sprite_animation_default_frames     = 3; 4; 5;
 
   $sprite_animation_end                    = *end*
-  
+  							  
 # shape
 
 $shape_factory                             = box2d_shape
-
 @$shape_scripts                            = 
-f32 shape_mass                             = 800.0
-f32 shape_radius                           = 0.0
-f32 shape_friction                         = 0.3
-f32 shape_elasticity                       = 0.15
-f32 shape_buoyancy                         = 0.8
-f32 shape_drag                             = 0.75
+f32 shape_mass                             = 500.0
+f32 shape_radius                           = 16.0	# pickup radius
+f32 shape_friction                         = 0.01
+f32 shape_elasticity                       = 0.2
+f32 shape_buoyancy                         = 0.7
+f32 shape_drag                             = 0.73
 bool shape_collides                        = yes
 bool shape_ladder                          = no
 bool shape_platform                        = no
  #block_collider
-@f32 verticesXY                            =  0.0; 0.0;  
-			   								  40.0; 0.0; 
-											  32.0; 10.0; 
-											  8.0; 10.0;	
+@f32 verticesXY                            =  8.0; 0.0;  
+			   								  24.0; 0.0; 
+			   								  32.0; 28.0;
+			   								  24.0; 32.0;
+			   								  8.0; 32.0;
+			   								  0.0; 28.0;
 u8 block_support                           = 0
 bool block_background                      = no
 bool block_lightpasses                     = no
 bool block_snaptogrid                      = no
 
-$movement_factory                          = 
+$movement_factory                          =
 $brain_factory                             =
 
-$attachment_factory                        = box2d_attachment	 
+$attachment_factory                        = box2d_attachment
 @$attachment_scripts                       = 
 # name; pixel offset (from center) X; offset Y; socket/plug 0/1; controller; radius
-@$attachment_points                        =  FLYER;   	   0;  -2;  0; 1; 7;
-											  VEHICLE; 		15;  -4;  0; 0; 0;		
-											  CARGO; 		0; 14;  0; 0; 0;		
-											  
-											  #for once this actually works properly.. 
-											  #PASSENGER;    20; -10;  0; 1; 7;
-											  #PASSENGER;    24; -20;  0; 1; 7;
-											  #PASSENGER;   -20; -10;  0; 1; 7;
-											  #PASSENGER;   -24; -20;  0; 1; 7;
+@$attachment_points                        = 
+											GUNNER; -11; 3; 0; 1; 12;
+											DRIVER; 2; 0; 0; 1; 12;
+											VEHICLE; 0;   8; 1; 0; 0;
+
 $inventory_factory                         = generic_inventory
 @$inventory_scripts                        = 
 u8 inventory_slots_width                   = 2
-u8 inventory_slots_height                  = 1
-$inventory_name                            = Bomber Compartment
+u8 inventory_slots_height                  = 3
+$inventory_name                            = Load
 
 # general
 
-$name                                      = bomber
-@$scripts                              = Vehicle.as;		
-										 Seats.as;
-										 Wooden.as;
-										 WoodenHit.as;
-										 HurtOnCollide.as;
-										 GenericHit.as;	
-										 CargoAttachment.as;
-										 VehicleConvert.as;
-										 VehicleAttachment.as;
-										 RunOverPeople.as;										 
-										 IsFlammable.as;
-										 BomberCommon.as;
-										 Bomber.as;
-										 GyromatSupport.as
-f32 health                                 = 20.0
+$name                                      = ballista
+@$scripts								   = 
+											 DecayInWater.as; 
+											 DecayIfFlipped.as;
+											 Seats.as;      # set this first
+											 Vehicle.as;
+											 Ballista.as;
+											 VehicleConvert.as;
+											 WoodVehicleDamages.as;
+											 Wooden.as;
+											 HurtOnCollide.as;
+											 GenericHit.as;  
+											 IsFlammable.as;	
+											 AutoGrabFromGround.as;
+											 Spawner.as;
+											 RunOverPeople.as;
+											 PopWheelsOff.as;
+											 GyromatSupport.as;
+f32 health                                 = 15.0
 # looks & behaviour inside inventory
-$inventory_name                            = Bomber
-$inventory_icon                        = -
-u8 inventory_icon_frame                = 0
-u8 inventory_icon_frame_width          = 0
-u8 inventory_icon_frame_height         = 0
+$inventory_name                            = Ballista
+$inventory_icon                        = VehicleIcons.png
+u8 inventory_icon_frame                = 1
+u8 inventory_icon_frame_width          = 32
+u8 inventory_icon_frame_height         = 32
 u8 inventory_used_width                    = 0
 u8 inventory_used_height                   = 0
 u8 inventory_max_stacks                    = 0

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Car/Car.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Car/Car.cfg
@@ -96,6 +96,7 @@ $name                                      = car
 										VehicleAttachment.as;
 										VehicleConvert.as;
 										DestructionAnimation.as;
+										GyromatSupport.as
 f32 health                                 = 15.0
 # looks & behaviour inside inventory
 $inventory_name                            = Motorized Horse

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Catapult/Catapult.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Catapult/Catapult.as
@@ -88,7 +88,7 @@ void onTick(CBlob@ this)
 		{
 			if (this.exists("gyromat_acceleration"))
 			{
-				v.cooldown_time = Maths::Max(0,v.cooldown_time-this.get_f32("gyromat_acceleration"));
+				v.cooldown_time = Maths::Max(0, v.cooldown_time-this.get_f32("gyromat_acceleration"));
 			}
 			else
 			{

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Catapult/Catapult.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Catapult/Catapult.as
@@ -86,7 +86,7 @@ void onTick(CBlob@ this)
 
 		if (v.cooldown_time > 0)
 		{
-			if(this.exists("gyromat_acceleration"))
+			if (this.exists("gyromat_acceleration"))
 			{
 				v.cooldown_time = Maths::Max(0,v.cooldown_time-this.get_f32("gyromat_acceleration"));
 			}
@@ -162,7 +162,7 @@ bool Vehicle_canFire(CBlob@ this, VehicleInfo@ v, bool isActionPressed, bool was
 		if (isActionPressed && charge < v.max_charge_time)
 		{
 			f32 chargeSpeed = 1;
-			if(this.exists("gyromat_acceleration"))
+			if (this.exists("gyromat_acceleration"))
 			{
 				chargeSpeed *= this.get_f32("gyromat_acceleration");
 				//print("ChargeSpeed "+chargeSpeed);
@@ -236,7 +236,7 @@ void Vehicle_onFire(CBlob@ this, VehicleInfo@ v, CBlob@ bullet, const u8 _charge
 		vel += (Vec2f((_r.NextFloat() - 0.5f) * 128, (_r.NextFloat() - 0.5f) * 128) * 0.01f);
 		vel.RotateBy(angle);
 
-		if(this.exists("gyromat_acceleration"))
+		if (this.exists("gyromat_acceleration"))
 		{
 			vel *= Maths::Sqrt(this.get_f32("gyromat_acceleration"));
 		}
@@ -252,7 +252,7 @@ void Vehicle_onFire(CBlob@ this, VehicleInfo@ v, CBlob@ bullet, const u8 _charge
 	// we override the default time because we want to base it on charge
 	int delay = 30 + (charge / (250 / 30));
 	v.fire_delay = delay;
-	if(this.exists("gyromat_acceleration"))
+	if (this.exists("gyromat_acceleration"))
 	{
 		v.fire_delay /= this.get_f32("gyromat_acceleration");
 	}

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Catapult/Catapult.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Catapult/Catapult.cfg
@@ -126,6 +126,7 @@ $name                                      = catapult
 										AutoGrabFromGround.as;	
 										RunOverPeople.as;
 										PopWheelsOff.as;
+										GyromatSupport.as
 f32 health                                 = 12.0
 # looks & behaviour inside inventory
 $inventory_name                            = Catapult

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Hoverbike/Hoverbike.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Hoverbike/Hoverbike.as
@@ -75,6 +75,11 @@ void onTick(CBlob@ this)
 			
 			Vec2f vel = Vec2f(h, v);
 			
+			if(this.exists("gyromat_acceleration"))
+			{
+				vel *= Maths::Sqrt(this.get_f32("gyromat_acceleration"));
+			}
+
 			this.AddForce(vel * this.getMass() * 0.50f);
 			this.SetFacingLeft(pilot.getAimPos().x < this.getPosition().x);
 			

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Hoverbike/Hoverbike.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Hoverbike/Hoverbike.as
@@ -75,7 +75,7 @@ void onTick(CBlob@ this)
 			
 			Vec2f vel = Vec2f(h, v);
 			
-			if(this.exists("gyromat_acceleration"))
+			if (this.exists("gyromat_acceleration"))
 			{
 				vel *= Maths::Sqrt(this.get_f32("gyromat_acceleration"));
 			}

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Hoverbike/Hoverbike.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Hoverbike/Hoverbike.cfg
@@ -76,6 +76,7 @@ $name                                             = hoverbike
 													NoPlayerCollision.as;
 													SetTeamToCarrier.as;
 													SetDamageToCarrier.as;
+													GyromatSupport.as
 f32 health                                        = 10.0
 $inventory_name                                   = Hoverbike
 $inventory_icon                                   = -

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/SteamTank/SteamTank.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/SteamTank/SteamTank.cfg
@@ -107,6 +107,7 @@ $name                                      = steamtank
 										VehicleConvert.as;
 										RunOverPeople.as;
 										DestructionAnimation.as;
+										GyromatSupport.as;
 f32 health                                 = 70.0
 # looks & behaviour inside inventory
 $inventory_name                            = Steam Tank


### PR DESCRIPTION
The following vehicles now work with gyromats: (Square root of effect)
Bomber
ArmoredBomber
ArmoredCar
Car
Catapult
SteamTank
Ballista

This does allow the car and the armored car to sort of fly at 2 to 3 gyromats due to how base kag handles vehicles, but considering the difficulty of obtaining gyromat and the durability of cars this seems fine, additionally this flying is quite hard to use