### PR TITLE
Faction map hide

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Camp/Camp.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Camp/Camp.as
@@ -25,7 +25,8 @@ void onInit(CBlob@ this)
 	this.set_bool("base_allow_alarm", false);
 	
 	this.addCommandID("sv_store");
-	
+	this.addCommandID("sv_hidemap");
+
 	this.Tag("minimap_small");
 	this.set_u8("minimap_index", 1);
 	
@@ -101,6 +102,8 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 		{
 			CButton@ buttonOwner = caller.CreateGenericButton(28, Vec2f(14, 5), this, this.getCommandID("sv_store"), "Store", params);
 		}
+
+		CButton@ buttonOwner = caller.CreateGenericButton(28, Vec2f(7, 2.5f), this, this.getCommandID("sv_hidemap"), "Hide On Map", params);
 	}
 }
 
@@ -145,6 +148,10 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			f32 heal = this.getInitialHealth() * 0.05f;
 			this.server_SetHealth(Maths::Min(this.getHealth() + heal, this.getInitialHealth()));
 		}
+	}
+	else if(cmd == this.getCommandID("sv_hidemap"))
+	{
+
 	}
 	
 	if (isServer())

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Camp/Camp.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/Camp/Camp.as
@@ -29,6 +29,7 @@ void onInit(CBlob@ this)
 
 	this.Tag("minimap_small");
 	this.set_u8("minimap_index", 1);
+	this.set_bool("minimap_hidden", false);
 	
 	// this.Tag("invincible");
 
@@ -103,7 +104,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 			CButton@ buttonOwner = caller.CreateGenericButton(28, Vec2f(14, 5), this, this.getCommandID("sv_store"), "Store", params);
 		}
 
-		CButton@ buttonOwner = caller.CreateGenericButton(28, Vec2f(7, 2.5f), this, this.getCommandID("sv_hidemap"), "Hide On Map", params);
+		CButton@ buttonOwner = caller.CreateGenericButton(this.get_bool("minimap_hidden") ? 23 : 27, Vec2f(0.5f, -14), this, this.getCommandID("sv_hidemap"), "Toggle Map Icon", params);
 	}
 }
 
@@ -149,9 +150,9 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			this.server_SetHealth(Maths::Min(this.getHealth() + heal, this.getInitialHealth()));
 		}
 	}
-	else if(cmd == this.getCommandID("sv_hidemap"))
+	else if (cmd == this.getCommandID("sv_hidemap"))
 	{
-
+		this.set_bool("minimap_hidden", !this.get_bool("minimap_hidden"));
 	}
 	
 	if (isServer())

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/CommonFactionBuilding.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/FactionBuildings/CommonFactionBuilding.as
@@ -120,8 +120,16 @@ void SetMinimap(CBlob@ this)
 		if (this.hasTag("minimap_large")) this.SetMinimapVars("GUI/Minimap/MinimapIcons.png", this.get_u8("minimap_index"), Vec2f(16, 8));
 		else if (this.hasTag("minimap_small")) this.SetMinimapVars("GUI/Minimap/MinimapIcons.png", this.get_u8("minimap_index"), Vec2f(8, 8));
 	}
-
-	this.SetMinimapRenderAlways(true);
+	if (this.get_bool("minimap_hidden"))
+	{
+		//print("hidden");
+		this.SetMinimapVars("GUI/Minimap/MinimapIcons.png", -1, Vec2f(8, 8)); //by setting the icon to nothing it is removed, this is a bit hacky but set minimap render doesn't seem to work
+	}
+	else
+	{
+		this.SetMinimapRenderAlways(true);
+	}
+	
 }
 
 void onChangeTeam(CBlob@ this, const int oldTeam)


### PR DESCRIPTION
Camps can now be hidden on the minimap, this toggle is only available for their faction members. More advanced faction buildings cannot be hidden.

This should improve the chances of newer factions against older factions as they will be able to hide on the map a bit.
