### PR TITLE
Fixed drill instant overheat in water bug

### DIFF
--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drill/Drill.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drill/Drill.as
@@ -173,7 +173,7 @@ void onTick(CBlob@ this)
 			{
 				makeSteamPuff(this, 0.5f, 5, false);
 			}
-			heat -= heat_cool_amount;
+			heat -= Maths::Min(heat, heat_cool_amount); //Cannot reduce heat below 0 (previously could)
 		}
 		this.set_u8(heat_prop, heat);
 		this.Sync(heat_prop, true);


### PR DESCRIPTION
When the drill had at least 2 heat and was underwater its heat was reduced by 5, since the heat is an unsigned int this lead to integer underflow causing overheating. This is now fixed (heat will only be reduced to 0 at most).