### PR TITLE
Chicken camp allows you to place blocks below it

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/CombatChickens/ChickenCamp/ChickenCamp.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/CombatChickens/ChickenCamp/ChickenCamp.as
@@ -10,7 +10,6 @@
 	
 	this.getSprite().SetZ(-50); //background
 	this.getShape().getConsts().mapCollisions = false;
-	this.set_Vec2f("nobuild extend", Vec2f(0.0f, 8.0f));
 	
 	this.Tag("minimap_small");
 	this.set_u8("minimap_index", 26);


### PR DESCRIPTION
The chicken camps no build zone extended below the camp itself. This was once a thing with all bases but was removed/fixed at some point I presume this base was missed.