### PR TITLE
Dynamite is tagged as an explosive

### DIFF
--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Weapons/Dynamite/Dynamite.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Weapons/Dynamite/Dynamite.as
@@ -23,6 +23,7 @@ void onInit(CBlob@ this)
 	this.set_bool("map_damage_raycast", true);
 	this.Tag("map_damage_dirt");
 	this.Tag("projectile");
+	this.Tag("explosive");
 
 	this.Tag("use hitmap");
 	this.set_f32("hitmap_chance", hitmap_chance);


### PR DESCRIPTION
This means the danger detector can detect it, also this just makes sense i mean you cant tell me dynamite isn't an explosive.