### PR TITLE
Changing Fallout Gas decay speed

### DIFF
--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/Fallout/FalloutGas.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/Fallout/FalloutGas.as
@@ -19,7 +19,7 @@ void onInit(CBlob@ this)
 
 	if (!this.exists("toxicity")) this.set_f32("toxicity", 5.00f);
 
-	this.server_SetTimeToDie((20 * 35) + XORRandom(20 * 35));
+	this.server_SetTimeToDie((20 * 12) + XORRandom(20 * 7));
 
 	if (isClient())
 	{


### PR DESCRIPTION
Changing the decay of the fallout gas or mithril gas from ROLF, nukes, and dirty bombs from 4-7 minutes, rather then 11.66-23.33 minutes. This is because 4-7 minutes is ample time to launch another nuke if you need more gas, also to reduce lag by having less blobs out (as there should be less logically over time). This also should stop the issue of spawns being inescapable, as the gas will dissipate much faster.