### PR TITLE
Fixed LootSystem code not using 0 element

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/LootSystem.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Structures/LootSystem.as
@@ -19,7 +19,7 @@ class LootItem
 void server_SpawnRandomItem(CBlob@ this, const LootItem@[]@&in items)
 {
     int index = GetRandomItem(@items);
-	if (index > 0 && index < items.length)
+	if (index >= 0 && index < items.length)
 	{
 		LootItem@ item = items[index];
 		MakeMat(this, this.getPosition(), item.blobname, item.base_count + XORRandom(item.bonus_count));

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/FriendBox/AnimalBox.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/FriendBox/AnimalBox.as
@@ -3,7 +3,6 @@
 // name, amount, bonus, weight
 LootItem@[] c_items =
 {
-	LootItem("chicken", 1, 2, 0), //repeated twice due to bug and im too lazy to fix legitimently
 	LootItem("chicken", 1, 2, 750),
 	LootItem("piglet", 1, 1, 500),
 	LootItem("kitten", 1, 1, 600),

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/MysteryBox/MysteryBox.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/MysteryBox/MysteryBox.as
@@ -3,7 +3,6 @@
 // name, amount, bonus, weight
 LootItem@[] c_items =
 {
-	LootItem("mat_stone", 25, 1000, 0),
 	LootItem("mat_stone", 25, 1000, 800),
 	LootItem("mat_wood", 25, 1000, 700),
 	LootItem("mat_gold", 25, 500, 400),


### PR DESCRIPTION
Now loot chests can actually drop stone, was previously spawning nothing if index == 0 since it needed index > 0