### PR TITLE
Vehicle-turret compatibility

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Scripts/RunnerCollision.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Scripts/RunnerCollision.as
@@ -18,6 +18,11 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 	}
 	else // collide only if not a player or other team member, or crouching
 	{
+		if (this.hasTag("seated"))
+		{
+			return false;
+		}
+
 		//other team member
 		if (blob.hasTag("player") && (this.getTeamNum()==blob.getTeamNum() && (this.getTeamNum()>=0 && this.getTeamNum()<7)))
 		{

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatHop.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatHop.as
@@ -77,7 +77,12 @@ void onTick(CBlob@ this)
 		if (closestAP !is null)
 		{
 			closestAP.getBlob().server_AttachTo(this, closestAP);
-			if (isServer() && (closestAP.name == "FLYER" || closestAP.name == "DRIVER")) closestAP.getBlob().server_setTeamNum(this.getTeamNum());
+
+			if (isServer() && (closestAP.name == "FLYER" || closestAP.name == "DRIVER" || 
+			   (closestAP.getBlob().hasTag("turret") && !closestAP.getBlob().isAttached())))
+			{
+				closestAP.getBlob().server_setTeamNum(this.getTeamNum());
+			}
 		}
 	}
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/Vehicle.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/Vehicle.as
@@ -1,6 +1,5 @@
 #include "SeatsCommon.as"
 #include "VehicleCommon.as"
-#include "VehicleAttachmentCommon.as"
 
 void onInit(CBlob@ this)
 {
@@ -184,6 +183,23 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (!this.get("VehicleInfo", @v)) return;
 
 		v.ammo_stocked = params.read_u16();
+	}
+}
+
+void onChangeTeam(CBlob@ this, const int oldTeam)
+{
+	//Convert attached turrets to same team as host vehicle
+	AttachmentPoint@[] aps;
+	if (this.getAttachmentPoints(@aps))
+	{
+		for (uint i = 0; i < aps.length; i++)
+		{
+			AttachmentPoint@ ap = aps[i];
+			if (ap.name == "VEHICLE" && ap.getBlob().hasTag("turret") && ap.getBlob() !is this)
+			{
+				ap.getBlob().server_setTeamNum(this.getTeamNum());
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Improves the connection between a vehicle's attached guns and the vehicle itself. Mainly for quality of life and easier use.

- Turret vehicles will change team according to their host vehicle if attached to one.
- Turret vehicles convert to the controller's team. (I consider this a bug fix)
- Sitting players do not collide, for easier movement between players.