### PR TITLE
Increased Atlar hp to 50

### DIFF
--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Altar.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Altar.cfg
@@ -62,7 +62,7 @@ $name                                             = altar
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 10.0
+f32_health                                        = 50.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Cocok/AltarCocok.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Cocok/AltarCocok.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_cocok
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 10.0
+f32_health                                        = 50.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Cocok
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Dragonfriend/AltarDragonfriend.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Dragonfriend/AltarDragonfriend.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_dragonfriend
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 10.0
+f32_health                                        = 50.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of the Dragon
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Foghorn/AltarFoghorn.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Foghorn/AltarFoghorn.cfg
@@ -63,7 +63,7 @@ $name                                             = altar_foghorn
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 10.0
+f32_health                                        = 50.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Foghorn
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Gregor/AltarGregor.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Gregor/AltarGregor.cfg
@@ -63,7 +63,7 @@ $name                                             = altar_gregor
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 10.0
+f32_health                                        = 50.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Gregor
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Ivan/AltarIvan.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Ivan/AltarIvan.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_ivan
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 10.0
+f32_health                                        = 50.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Ivan
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mason/AltarMason.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mason/AltarMason.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_mason
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 10.0
+f32_health                                        = 50.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Grand Mason
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mithrios/AltarMithrios.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mithrios/AltarMithrios.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_mithrios
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 10.0
+f32_health                                        = 50.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Mithrios
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/SwagLag/AltarSwagLag.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/SwagLag/AltarSwagLag.cfg
@@ -63,7 +63,7 @@ $name                                             = altar_swaglag
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 10.0
+f32_health                                        = 50.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Swag
 $inventory_icon                                   = Altar.png


### PR DESCRIPTION
Increases the hp of each altar from 10 to 50 to make them less easy to destroy with any stray damage
To Compare the camp basic faction building has 150 hp
This also feels nice considering most altars are massive stone blocks costing at least 2000 stone