### PR TITLE
Reworked Gas Extractor (the item) Force

### DIFF
--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/GasExtractor/GasExtractor.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/GasExtractor/GasExtractor.as
@@ -72,7 +72,9 @@ void onTick(CBlob@ this)
 							if (rmb) dir = -dir;
 
 							// print("" + blob.getMass());
-							blob.AddForce(dir * (Maths::Clamp(maxDistance - dist, 0, maxDistance) * 0.80f));
+							blob.AddForce(dir * Maths::Min(50, blob.getMass()) * ((maxDistance - dist) / maxDistance * 0.80f));
+
+							
 
 							if (lmb)
 							{


### PR DESCRIPTION
Now no longer ignores mass (since in tc mass is uselss a single methane cloud weighs 40 which is nearly as much as a builder)
this is also why previously it flung single wood pieces sky high into the sky with a single press of the button
Generall makes it feel more consistant and reliable