### PR TITLE
Damaged Glass background stopping water

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/MapLoaders/LoadTCPNG.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/MapLoaders/LoadTCPNG.as
@@ -2224,7 +2224,7 @@ void OnGlassTileHit(CMap@ map, u32 index)
 
 void OnBGlassTileHit(CMap@ map, u32 index)
 {
-	map.AddTileFlag(index, Tile::BACKGROUND | Tile::LIGHT_PASSES);
+	map.AddTileFlag(index, Tile::BACKGROUND | Tile::LIGHT_PASSES | Tile::WATER_PASSES | Tile::LIGHT_SOURCE);
 
 	if (isClient())
 	{


### PR DESCRIPTION
Damaged glass background used to stop water allowing for easy water blocking tiles which don't block movement.
This is the fix since its obviously not intentional, quite strong, and very weird.