### PR TITLE
Wood on Respawn

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Gamemode/Rules/Scripts/Survival_Rules.as
@@ -578,6 +578,10 @@ bool doDefaultSpawn(CPlayer@ player, string blobType, u8 team, bool ignoreDisabl
 					MakeMat(new_blob, r.getPosition(), "mat_wood", 100);
 					MakeMat(new_blob, r.getPosition(), "mat_stone", 75);
 				}
+				else
+				{
+					MakeMat(new_blob, r.getPosition(), "mat_wood", 25);
+				}
 			}
 
 			return true;


### PR DESCRIPTION
When neutrals respawn they now receive 25 wood which is enough to build 2 ladders which should help a bit.
(This only triggers on normal respawns (bandit shack and ruin) but wont trigger with taverns)
This means that the more neutrals die the more wood they have to at least build some defense or other supporting structures.
It also means they can afford 2 ladders to get out of really bad situations or reach a shop. (In case the map is a huge deadly mess)

Also mentioned in #161 