### PR TITLE
Altar Pickaxable

### DIFF
--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Altar.as
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Altar.as
@@ -34,6 +34,7 @@ void onInit(CBlob@ this)
 {
 	this.set_Vec2f("shop offset", Vec2f(0, 0));
 	this.set_TileType("background tile", CMap::tile_castle_back);
+	this.Tag("builder always hit");
 	
 	if (!this.exists("deity_id")) this.set_u8("deity_id", Deity::none);
 	


### PR DESCRIPTION
All Altars can now be hit via pickaxe.
This will take quite the long time to destroy the altar but still allows you to remove an altar in your base without blowing up your own base.