### PR TITLE
Neutral doors (the specific blob not all doors which are neutral) were stony

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Door/NeutralDoor.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Door/NeutralDoor.cfg
@@ -6,7 +6,7 @@
 
 $sprite_factory                            = generic_sprite
 
-@$sprite_scripts                           = Stone.as;
+@$sprite_scripts                           = Wooden.as;
 											 FireAnim.as;
 $sprite_texture                            = 1x1NeutralDoor.png
 s32_sprite_frame_width                     = 16
@@ -17,7 +17,7 @@ f32 sprite_offset_y                        = 0
 	$sprite_gibs_start                     = *start*
 
 	$gib_type                              = predefined
-	$gib_style                             = stone
+	$gib_style                             = wooden
 	u8 gib_count                           = 5
 	@u8 gib_frame                          = 4; 5; 6; 7;
 	f32 velocity                           = 10.0
@@ -93,8 +93,9 @@ $inventory_factory                         =
 
 $name                                      = neutral_door
 @$scripts                                  = SwingDoor.as;
-											 StoneHit.as;
-											 Stone.as;
+											 isFlammable.as;
+											 WoodenHit.as;
+											 Wooden.as;
 											 GenericHit.as;
 											 FallOnNoSupport.as;
 											 CollapseMissingAdjacent.as;


### PR DESCRIPTION
Now they are wooden, this includes beeing flammable, and creating the right gibs and damage resistances.
Note the sprite for neutral doors WAS and IS the normal wooden door so it just looked really weird before this fix.