### PR TITLE
Bubble gem rework

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Scripts/RunnerDrowning.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Scripts/RunnerDrowning.as
@@ -54,8 +54,6 @@ void onTick(CBlob@ this)
 	const bool server = isServer();				
 	const bool client = isClient();				
 
-	if (this.hasTag("bubblegem")) canBreathe = !canBreathe;
-	
 	if (!canBreathe)
 	{
 		if (aircount >= FREQ)
@@ -115,8 +113,6 @@ void onTick(CBlob@ this)
 
 	this.set_u8("air_count", aircount);
 	this.Sync("air_count", true);
-	
-	this.Untag("bubblegem");
 }
 
 // SPRITE renders in party indicator

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/BubbleGem/BubbleGem.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/BubbleGem/BubbleGem.as
@@ -1,15 +1,20 @@
 void onTick(CBlob@ this){
 
-	// if(isServer())
-	// if (getGameTime() % 30 == 0){
-	
-		// if(this.getInventoryBlob() !is null)
-		// this.getInventoryBlob().server_Heal(0.25f);
-	
-	// }
-
-	if(this.getInventoryBlob() !is null)
-	this.getInventoryBlob().Tag("bubblegem");
+	if (getGameTime() % 60 == 0)
+	{
+		if (this.getInventoryBlob() !is null) //Harder to use for automation since blob needs to be in water to heal
+		{
+			CBlob@ inv = this.getInventoryBlob();
+			if (inv.isInWater() && inv.hasTag("flesh"))
+			{
+				if (isServer()) inv.server_Heal(0.5f); //Healing amount is doubled from 0.25 but it only ticks every 60 ticks
+			}
+			else //Hiccups
+			{
+				inv.AddForce(Vec2f(XORRandom(3)-1,-1) * inv.getMass()); //While you arent in water it will move you around a bit (with enough you will flop around like a fish on land)
+			}
+		}
+	}
 }
 
 void onThisAddToInventory(CBlob@ this, CBlob@ inventoryBlob)

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Witch/WitchShack.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Witch/WitchShack.as
@@ -73,7 +73,7 @@ void onInit(CBlob@ this)
 		s.spawnNothing = true;
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Terdla's Bubble Gem", "$bubble_gem$", "bubblegem", "A useless pretty blue gem!");
+		ShopItem@ s = addShopItem(this, "Terdla's Bubble Gem", "$bubble_gem$", "bubblegem", "A useless pretty blue gem! May cause hiccups");
 		AddRequirement(s.requirements, "coin", "", "Coins", 200);
 		s.spawnNothing = true;
 	}


### PR DESCRIPTION
The bubble gem now no longer drowns you and now is back to healing you, BUT it only heals flesh things (no more healing tanks) and ONLY works while your in water, this also means its more difficult to use for healing automation. As an additional downside bubble gems inside your inventory while your not in water will cause you to get hiccups throwing you around a bit (Scales with amount of gems)