### PR TITLE
Minor Bug Fixes and Tweaks

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/BuilderCommon.as
@@ -41,7 +41,7 @@ Vec2f getBuildingOffsetPos(CBlob@ blob, CMap@ map, Vec2f required_tile_space)
 
 CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 {
-	if(index >= blocks.length)
+	if (index >= blocks.length)
 	{
 		return null;
 	}
@@ -53,18 +53,18 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 	this.set_TileType("buildtile", 0);
 
 	CBlob@ anotherBlob = inv.getItem(b.name);
-	if(isServer() && anotherBlob !is null && this !is null)
+	if (isServer() && anotherBlob !is null && this !is null)
 	{
 		this.server_Pickup(anotherBlob);
 		this.set_u8("buildblob", 255);
 		return null;
 	}
 
-	if(canBuild(this, blocks, index))
+	if (canBuild(this, blocks, index))
 	{
 		Vec2f pos = this.getPosition();
 
-		if(b.buildOnGround)
+		if (b.buildOnGround)
 		{
 			const bool onground = this.isOnGround();
 
@@ -75,7 +75,7 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 			Vec2f space = Vec2f(b.size.x / 8, b.size.y / 8);
 			Vec2f offsetPos = getBuildingOffsetPos(this, map, space);
 
-			if(!fail)
+			if (!fail)
 			{
 				// check every tile space of the built blob for "no build sector" or "solid tile"
 				for(f32 step_x = 0.0f; step_x < space.x ; ++step_x)
@@ -94,7 +94,7 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 				// if we still havent failed
 				// check if we're making a building
 				// -> need to do some additional checking
-				if(!fail && b.name == "building")
+				if (!fail && b.name == "building")
 				{
 					Vec2f tl = Vec2f(offsetPos.x, offsetPos.y);
 					Vec2f br = Vec2f(offsetPos.x + b.size.x, offsetPos.y + b.size.y);
@@ -120,12 +120,12 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 							Vec2f dif = Vec2f(Maths::Abs(o_pos.x - b_pos.x), Maths::Abs(o_pos.y - b_pos.y));
 							Vec2f total = o_half + b_half;
 							Vec2f sep = total - dif;
-							if(sep.x > allow_overlap && sep.y > allow_overlap)
+							if (sep.x > allow_overlap && sep.y > allow_overlap)
 							{
 								//check if they aren't on the ignore list
 								//done here to avoid a bunch of string comp earlier
 								string o_name = o_blob.getName();
-								if(o_name != "bush" && !o_blob.hasTag("projectile"))
+								if (o_name != "bush" && !o_blob.hasTag("projectile"))
 								{
 									fail = true;
 									break;
@@ -144,17 +144,29 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 						CBlob@ e = blobs[i];
 						Vec2f vector = e.getPosition() - pos;
 						f32 distance = vector.getLength();
-						if(/*e.getTeamNum() != this.getTeamNum() &&*/distance <= 256 && distance >= 8)
+						if (e.hasTag("faction_base") && e.getTeamNum() != this.getTeamNum() && distance <= 320 && distance >= 8)
+						{
+							fail = true;
+							if (this.isMyPlayer()) client_AddToChat("There is an enemy faction base too close!", SColor(0xff444444));
+							break;
+						}
+						else if (e.hasTag("faction_base") && distance <= 224 && distance >= 8)
 						{
 							fail = true;
 							if (this.isMyPlayer()) client_AddToChat("There is a faction base too close!", SColor(0xff444444));
+							break;
+						}
+						else if (e.hasTag("upf_base") && distance <= 256 && distance >= 8)
+						{
+							fail = true;
+							if (this.isMyPlayer()) client_AddToChat("There is a UPF base too close!", SColor(0xff444444));
 							break;
 						}
 					}
 				}
 			}
 
-			if(fail)
+			if (fail)
 			{
 				if (this.isMyPlayer())
 				{
@@ -173,7 +185,7 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 			SendGameplayEvent(createBuiltBlobEvent(this.getPlayer(), b.name));
 		}
 
-		if(isServer())
+		if (isServer())
 		{
 			if (b.name == "camp" && this.getTeamNum() >= 100)
 			{
@@ -225,7 +237,8 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 			}
 			else
 			{
-				u8 myTeam = (this.getTeamNum() >= 100 && this.getTeamNum() != 250) ? -1 : this.getTeamNum();
+				bool trapBlocks = (b.name == "trap_block" || b.name == "spikes");
+				u8 myTeam = (this.getTeamNum() >= 100 && this.getTeamNum() != 250 && !trapBlocks) ? -1 : this.getTeamNum();
 				CBlob@ blockBlob = server_CreateBlob(b.name, myTeam, pos);
 				if (blockBlob !is null)
 				{
@@ -259,13 +272,13 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 							bp.setPosition(this.getPosition());
 						}
 					}
-					else if(b.name == "banner")
+					else if (b.name == "banner")
 					{
 						CPlayer@ p = this.getPlayer();
 						CRules@ r = getRules();
-						if(p !is null && r !is null)
+						if (p !is null && r !is null)
 						{
-							if(r.exists("clanData"+p.getUsername().toLower()))
+							if (r.exists("clanData"+p.getUsername().toLower()))
 							{
 								blockBlob.set_string("cData",r.get_string("clanData"+p.getUsername().toLower()));
 								blockBlob.Sync("cData",false);
@@ -276,7 +289,7 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 
 					if (blockBlob.hasTag("building")) return null;
 
-					if(blockBlob !is null && this !is null)
+					if (blockBlob !is null && this !is null)
 					{
 						this.server_Pickup(blockBlob);
 						this.set_u8("buildblob", index);
@@ -302,7 +315,7 @@ CBlob@ server_BuildBlob(CBlob@ this, BuildBlock[]@ blocks, uint index)
 
 bool canBuild(CBlob@ this, BuildBlock[]@ blocks, uint index)
 {
-	if(index >= blocks.length)
+	if (index >= blocks.length)
 	{
 		return false;
 	}
@@ -311,7 +324,7 @@ bool canBuild(CBlob@ this, BuildBlock[]@ blocks, uint index)
 
 	BlockCursor @bc;
 	this.get("blockCursor", @bc);
-	if(bc is null)
+	if (bc is null)
 	{
 		return false;
 	}
@@ -330,7 +343,7 @@ void ClearCarriedBlock(CBlob@ this)
 
 	// remove carried block, if any
 	CBlob@ carried = this.getCarriedBlob();
-	if(carried !is null && carried.hasTag("temp blob"))
+	if (carried !is null && carried.hasTag("temp blob"))
 	{
 		carried.Untag("temp blob");
 		carried.server_Die();

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/CommonBuilderBlocks.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/CommonBuilderBlocks.as
@@ -598,7 +598,7 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks, int teamnum = 7)
 		BuildBlock b(0, "shifter", "$shifter$", "Shifter\n Moves things in a set direction, has a cooldown.");
 		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 20);
 		AddRequirement(b.reqs, "blob", "mat_stone", "Stone", 10);
-		AddRequirement(b.reqs, "blob", "mat_copperwire", "Copper Wire", 2);
+		AddRequirement(b.reqs, "blob", "mat_copperwire", "Copper Wire", 1);
 		blocks[2].push_back(b);
 	}
 

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/CommonBuilderBlocks.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Characters/Builder/CommonBuilderBlocks.as
@@ -397,8 +397,8 @@ void addCommonBuilderBlocks(BuildBlock[][]@ blocks, int teamnum = 7)
 	}
 	{
 		BuildBlock b(0, "camp", "$icon_camp$", "Camp\nA basic faction base. Can be upgraded to gain\nspecial functions and more durability.\n\n$GREEN$Increases Upkeep cap by 1.$GREEN$\n");
-		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 500);
-		AddRequirement(b.reqs, "blob", "mat_stone", "Stone", 500);
+		AddRequirement(b.reqs, "blob", "mat_wood", "Wood", 375);
+		AddRequirement(b.reqs, "blob", "mat_stone", "Stone", 250);
 		AddRequirement(b.reqs, "coin", "", "Coins", 100);
 		b.buildOnGround = true;
 		b.size.Set(80, 24);

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/BigFoodCan/BigFoodCan.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/BigFoodCan/BigFoodCan.as
@@ -39,7 +39,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream@ params)
 
 			if (blob !is null)
 			{
-				blob.server_Heal(2.0f);
+				blob.server_Heal(5.0f);
 
 				if (this.get_u8("food_amount") <= 1) this.server_Die();
 				else

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Food/Eatable.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Food/Eatable.as
@@ -26,14 +26,17 @@ void Heal(CBlob@ this, CBlob@ blob)
 		string name = this.getName();
 
 		if (name == "heart") heal_amount = 1;
-		else if (name == "ratburger") heal_amount = 3;
-		else if (name == "ratfood") heal_amount = 2;
-		else if (name == "food") heal_amount = 4;
-		else if (name == "cake") heal_amount = 3;
-		else if (name == "foodcan") heal_amount = 20;
-		else if (name == "pumpkin") heal_amount = 7;
-		else if (name == "icecream") heal_amount = 2;
-		else if (name == "doritos") heal_amount = 8;
+		else if (name == "cake") 		heal_amount = 3;
+		else if (name == "food") 		heal_amount = 4;
+		else if (name == "foodcan") 	heal_amount = 20;
+		else if (name == "grain") 		heal_amount = 2;
+		else if (name == "ratfood") 	heal_amount = 2;
+		else if (name == "ratburger") 	heal_amount = 3;
+		else if (name == "pumpkin") 	heal_amount = 7;
+		else if (name == "steak") 		heal_amount = 4;
+		else if (name == "icecream") 	heal_amount = 3;
+		else if (name == "doritos") 	heal_amount = 8;
+		else heal_amount = 4; // things that must've been missed
 
 		params.write_u8(heal_amount);
 

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/Mustard/Mustard.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/Mustard/Mustard.as
@@ -31,7 +31,7 @@ void onTick(CBlob@ this)
 		for (uint i = 0; i < blobSize; i++)
 		{
 			CBlob@ blob = blobsInRadius[i];
-			if (blob is null || !blob.hasTag("flesh") || blob.hasTag("gas") || blob.hasTag("gas immunity") || !blob.isCollidable()) { continue; }
+			if (blob is null || !blob.hasTag("flesh") || blob.hasTag("gas") || blob.hasTag("gas immune") || !blob.isCollidable()) { break; }
 
 			blob.set_u8("mustard value", Maths::Clamp(blob.get_u8("mustard value") + 1, 0, 64));
 		

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Altar.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Altar.cfg
@@ -62,7 +62,7 @@ $name                                             = altar
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 50.0
+f32_health                                        = 20.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Cocok/AltarCocok.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Cocok/AltarCocok.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_cocok
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 50.0
+f32_health                                        = 20.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Cocok
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Dragonfriend/AltarDragonfriend.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Dragonfriend/AltarDragonfriend.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_dragonfriend
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 50.0
+f32_health                                        = 20.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of the Dragon
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Foghorn/AltarFoghorn.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Foghorn/AltarFoghorn.cfg
@@ -63,7 +63,7 @@ $name                                             = altar_foghorn
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 50.0
+f32_health                                        = 20.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Foghorn
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Gregor/AltarGregor.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Gregor/AltarGregor.cfg
@@ -63,7 +63,7 @@ $name                                             = altar_gregor
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 50.0
+f32_health                                        = 20.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Gregor
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Ivan/AltarIvan.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Ivan/AltarIvan.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_ivan
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 50.0
+f32_health                                        = 20.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Ivan
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mason/AltarMason.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mason/AltarMason.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_mason
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 50.0
+f32_health                                        = 20.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Grand Mason
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mithrios/AltarMithrios.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Mithrios/AltarMithrios.cfg
@@ -64,7 +64,7 @@ $name                                             = altar_mithrios
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 50.0
+f32_health                                        = 20.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Mithrios
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/SwagLag/AltarSwagLag.cfg
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/SwagLag/AltarSwagLag.cfg
@@ -63,7 +63,7 @@ $name                                             = altar_swaglag
 													DieOnCollapse.as;
 													SimpleSupport.as;
 													Shop.as;
-f32_health                                        = 50.0
+f32_health                                        = 20.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Altar of Swag
 $inventory_icon                                   = Altar.png

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/CeilingLamp/CeilingLamp.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/CeilingLamp/CeilingLamp.as
@@ -11,7 +11,7 @@ void onInit(CBlob@ this)
 	this.Tag("builder always hit");
 
 	this.SetLight(true);
-	this.SetLightRadius(72.0f);
+	this.SetLightRadius(128.0f);
 	this.SetLightColor(SColor(255, 255, 240, 210));
 	
 	this.set_bool("security_state", true);

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/ChickenMarket/ChickenMarket.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/ChickenMarket/ChickenMarket.as
@@ -182,7 +182,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 		u16 caller, item;
 
-		if(!params.saferead_netid(caller) || !params.saferead_netid(item))
+		if (!params.saferead_netid(caller) || !params.saferead_netid(item))
 			return;
 
 		string name = params.read_string();
@@ -201,7 +201,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 
 				callerPlayer.server_setCoins(callerPlayer.getCoins() +  parseInt(spl[1]));
 			}
-			else if(spl[0] == "lotteryticket")
+			else if (spl[0] == "lotteryticket")
 			{
 				CBlob@ blob = server_CreateBlobNoInit("lotteryticket");
 				blob.set_u16("value", XORRandom(50000));
@@ -219,12 +219,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 				{
 					callerBlob.server_PutInInventory(blob);
 				}
-			}
-			else if (spl[0] == "armoredcar")
-			{
-				CBlob@ crate = server_MakeCrate("armoredcar", "Armored Car", 0, callerBlob.getTeamNum(), this.getPosition(), false);
-				crate.Init();
-				callerBlob.server_Pickup(crate);
 			}
 			else if (spl[0] == "buyshop")
 			{
@@ -270,10 +264,6 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 			}
 			else
 			{
-				CBlob@ blob = server_CreateBlob(spl[0], callerBlob.getTeamNum(), this.getPosition());
-
-				if (blob is null) return;
-
 				if (this.get_string("shop_owner") != "")
 				{
 					CPlayer@ owner = getPlayerByUsername(this.get_string("shop_owner"));
@@ -284,13 +274,27 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 					}
 				}
 
-				if (!blob.canBePutInInventory(callerBlob))
+				if (spl[0] == "armoredcar")
 				{
-					callerBlob.server_Pickup(blob);
+					CBlob@ crate = server_MakeCrate("armoredcar", "Armored Car", 0, callerBlob.getTeamNum(), this.getPosition(), false);
+					crate.Init();
+					callerBlob.server_Pickup(crate);
 				}
-				else if (callerBlob.getInventory() !is null && !callerBlob.getInventory().isFull())
+				else
 				{
-					callerBlob.server_PutInInventory(blob);
+
+					CBlob@ blob = server_CreateBlob(spl[0], callerBlob.getTeamNum(), this.getPosition());
+
+					if (blob is null) return;
+
+					if (!blob.canBePutInInventory(callerBlob))
+					{
+						callerBlob.server_Pickup(blob);
+					}
+					else if (callerBlob.getInventory() !is null && !callerBlob.getInventory().isFull())
+					{
+						callerBlob.server_PutInInventory(blob);
+					}
 				}
 			}
 		}
@@ -342,7 +346,7 @@ void GetButtonsFor(CBlob@ this, CBlob@ caller)
 
 	//rename the market
 	CBlob@ carried = caller.getCarriedBlob();
-	if(carried !is null && carried.getName() == "paper" && caller.getTeamNum() == this.getTeamNum())
+	if (carried !is null && carried.getName() == "paper" && caller.getTeamNum() == this.getTeamNum())
 	{
 		CBitStream params;
 		params.write_u16(caller.getNetworkID());

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Door/DoorCommon.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Door/DoorCommon.as
@@ -16,7 +16,7 @@ bool canOpenDoor(CBlob@ this, CBlob@ blob)
 
 	if ((blob.getShape().getConsts().collidable) &&
 	        (blob.getRadius() > 5.0f) && //large
-	        (this.getTeamNum() == 255 || this.getTeamNum() == blob.getTeamNum() || (blob.getTeamNum() > 100 && blob.getTeamNum() < 200 && lockdown_passable)) &&
+	        (this.getTeamNum() == 255 || this.getTeamNum() == blob.getTeamNum() || (blob.getTeamNum() >= 100 && blob.getTeamNum() < 200 && lockdown_passable)) &&
 	        (blob.hasTag("player") || blob.hasTag("vehicle") || blob.hasTag("can open door"))) //tags that can open doors
 	{
 		

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Shifter/Shifter.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Shifter/Shifter.cfg
@@ -70,7 +70,7 @@ $name                                             = shifter
 													TileBackground.as;
 													DefaultNoBuild.as;
 													
-f32_health                                        = 3.0
+f32_health                                        = 2.0
 # looks & behaviour inside inventory
 $inventory_name                                   = Shifter
 $inventory_icon                                   = Shifter.png

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Merchant/Merchant.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Merchant/Merchant.as
@@ -136,12 +136,12 @@ void onInit(CBlob@ this)
 		s.spawnNothing = true;
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Sell Grain (1)", "$COIN$", "coin-40", "Sell 1 grain for 40 coins.");
+		ShopItem@ s = addShopItem(this, "Sell Grain (1)", "$COIN$", "coin-50", "Sell 1 grain for 50 coins.");
 		AddRequirement(s.requirements, "blob", "grain", "Grain", 1);
 		s.spawnNothing = true;
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Sell Grain (5)", "$COIN$", "coin-200", "Sell 5 grain for 200 coins.");
+		ShopItem@ s = addShopItem(this, "Sell Grain (5)", "$COIN$", "coin-250", "Sell 5 grain for 250 coins.");
 		AddRequirement(s.requirements, "blob", "grain", "Grain", 5);
 		s.spawnNothing = true;
 	}

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Tavern/Tavern.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Tavern/Tavern.cfg
@@ -77,7 +77,7 @@ $name                                      = tavern
 											 SimpleSupport.as;
 											 WoodenHit.as;
 											 Wooden.as;
-f32_health                                 = 15.0
+f32_health                                 = 10.0
 # looks & behaviour inside inventory
 $inventory_name                            = Some Cozy Tavern
 $inventory_icon                            = Tavern.png

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/TinkerTable/TinkerTable.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/TinkerTable/TinkerTable.as
@@ -162,7 +162,7 @@ void onInit(CBlob@ this)
 	}
 	{
 		ShopItem@ s = addShopItem(this, "Flashlight", "$icon_flashlight$", "flashlight", "Miraculous light in a tube! Illuminates the area it's pointing at.");
-		AddRequirement(s.requirements, "blob", "lantern", "Lantern", 1);
+		AddRequirement(s.requirements, "blob", "mat_copperwire", "Copper Wire", 2);
 		AddRequirement(s.requirements, "blob", "mat_ironingot", "Iron Ingot", 2);
 		AddRequirement(s.requirements, "coin", "", "Coins", 30);
 

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/TinkerTable/TinkerTable.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/TinkerTable/TinkerTable.as
@@ -199,7 +199,7 @@ void onInit(CBlob@ this)
 	{
 		ShopItem@ s = addShopItem(this, "Accelerated Gyromat Core Replacement", "$icon_gyromat$", "gyromat", "Replace this Accelerated Gyromat's core in hope to improve it.");
 		AddRequirement(s.requirements, "blob", "gyromat", "Gyromat", 1);
-		AddRequirement(s.requirements, "blob", "mat_copperwire", "Copper Wire", 20);
+		AddRequirement(s.requirements, "blob", "mat_copperwire", "Copper Wire", 10);
 		AddRequirement(s.requirements, "coin", "", "Coins", 400);
 
 		s.spawnNothing = true;


### PR DESCRIPTION
- Altars 50 health to 20
- Armored Car now properly receives discount
- Team 100 neutral lockdown bug fixed
- Bigfoodcan now gives more health
- Shifters are now cheaper and easier to remove
- Cheaper Gyro core scramble
- Better Ceiling lamps
- Faction distance now depends on whether it's UPF or enemy or team base