### PR TITLE
Gunwork

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Guns/CoreGunCode/Bullet.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Guns/CoreGunCode/Bullet.as
@@ -43,7 +43,7 @@ class Bullet
         CurrentPos = pos;
 
         BulletGrav = settings.B_GRAV;
-        FacingLeft = humanBlob.isFacingLeft();
+        FacingLeft = gun.isFacingLeft();
 
         TimeLeft = settings.B_TTL;
         Speed = settings.B_SPEED;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Guns/CoreGunCode/Bullet.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Guns/CoreGunCode/Bullet.as
@@ -156,8 +156,7 @@ class Bullet
 
                                 if (blob.getTeamNum() == gunBlob.getTeamNum() && !blob.getShape().isStatic()) continue;
                                 else if (blob.hasTag("weapon") || blob.hasTag("dead") || blob.hasTag("invincible") || 
-                                         blob.hasTag("food")   || blob.hasTag("gas")) continue;
-
+                                         blob.hasTag("food")   || blob.hasTag("gas")  || blob.isAttachedTo(hoomanShooter)) continue;
                                 else if (blob.getName() == "iron_halfblock" || blob.getName() == "stone_halfblock") continue;
 
                                 CurrentPos = hitpos;

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Guns/StandardFire.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Guns/StandardFire.as
@@ -166,10 +166,14 @@ void onTick(CBlob@ this)
 							settings.B_TYPE == HittersTC::shotgun         ? "shotgunCase": "";
 			f32 oAngle = (aimangle % 360) + 180;
 
+			// Shooting
+			const bool can_shoot = holder.isAttached() && holder.getName() != "automat" ? 
+					   holder.isAttachedToPoint("PASSENGER") || holder.isAttachedToPoint("PILOT") : true;
+
 			// Keys
-			const bool pressing_shoot = holder.isAttached() && holder.getName() != "automat" ? false : this.hasTag("CustomSemiAuto") ?
+			const bool pressing_shoot = (this.hasTag("CustomSemiAuto") ?
 					   point.isKeyJustPressed(key_action1) || holder.isKeyJustPressed(key_action1) : //automatic
-					   point.isKeyPressed(key_action1) || holder.isKeyPressed(key_action1); //semiautomatic
+					   point.isKeyPressed(key_action1) || holder.isKeyPressed(key_action1)); //semiautomatic
 
 			// Sound
 			const f32 reload_pitch = this.exists("CustomReloadPitch") ? this.get_f32("CustomReloadPitch") : 1.0f;
@@ -246,7 +250,7 @@ void onTick(CBlob@ this)
 
 				if (this.hasTag("CustomShotgunReload")) this.set_bool("doReload", false);
 			} 
-			else if (pressing_shoot)
+			else if (pressing_shoot && can_shoot)
 			{
 				if (this.get_u8("clip") > 0)
 				{

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatHop.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatHop.as
@@ -58,10 +58,10 @@ void onTick(CBlob@ this)
 				if (distance <= ap.radius + 4.0f)
 				{
 					// cheat - attached objects have closer seats (cata in boat)
-					if (ap.getBlob().isAttached())
+					/*if (ap.getBlob().isAttached())
 					{
 						distance *= 0.3f;
-					}
+					}*/
 
 					if (distance < closestDist)
 					{

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatsGUI.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Vehicles/SeatsGUI.as
@@ -82,7 +82,7 @@ void onRender(CSprite@ this)
 
 					GUI::DrawIconByName("$down_arrow$", pos);
 
-					if (g_debug == 0)
+					if (g_debug == 1)
 					{
 						lastPointName = ap.name;  // draw just one of a kind
 					}

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/GasExtractor/GasExtractor.cfg
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/GasExtractor/GasExtractor.cfg
@@ -75,6 +75,7 @@ $inventory_factory                      =
 $name                                   = gasextractor
 @$scripts                               = GasExtractor.as;
                                           Wooden.as;
+                                          NoPlayerCollision.as;
 f32 health                              = 3.0
 # looks & behaviour inside inventory
 $inventory_name                         = Zapthrottle Gas Extractor

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/CargoContainer/CargoContainer.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/CargoContainer/CargoContainer.cfg
@@ -54,9 +54,9 @@ $attachment_factory                               = box2d_attachment
 @$attachment_scripts                              =
 @$attachment_points                               = PICKUP; -1; 4; 1; 0; 0;
 													CARGO; 0; -10; 1; 0; 0;	
-													PASSENGER0; -12; 0; 0; 0; 8;
-													PASSENGER1; 4; 0; 0; 0; 8;
-													PASSENGER2; 20; 0; 0; 0; 8;
+													PASSENGER; -12; 0; 0; 0; 8;
+													PASSENGER; 4; 0; 0; 0; 8;
+													PASSENGER; 20; 0; 0; 0; 8;
 
 $inventory_factory                                = generic_inventory
 @$inventory_scripts                               =

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.as
@@ -98,7 +98,7 @@ bool isInventoryAccessible(CBlob@ this, CBlob@ forBlob)
 	if (this.getTeamNum() != forBlob.getTeamNum()) return false;
 
 	CBlob@ carried = forBlob.getCarriedBlob();
-	return (carried is null ? true : carried.getName() == "mat_gatlingammo");
+	return (carried is null ? true : carried.getName() == "mat_gatlingammo" && !forBlob.isAttached());
 }
 
 u8 GetAmmo(CBlob@ this)

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.cfg
@@ -61,7 +61,7 @@ $attachment_factory                    = box2d_attachment
 $inventory_factory                     = generic_inventory
 @$inventory_scripts                    = 
 u8 inventory_slots_width               = 1
-u8 inventory_slots_height              = 3
+u8 inventory_slots_height              = 1
 $inventory_name                        = Requires Gatling Ammunition
 
 # general

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/AK47/AK47.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/AK47/AK47.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	settings.B_SPREAD = 5; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.007); //Bullet gravity drop
 	settings.B_SPEED = 55; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 13; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 20; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 1.15f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::bullet_high_cal; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/AssaultRifle/AssaultRifle.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/AssaultRifle/AssaultRifle.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	settings.B_SPREAD = 4; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.006); //Bullet gravity drop
 	settings.B_SPEED = 70; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 15; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 18; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 1.50f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::bullet_high_cal; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/Carbine/Carbine.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/Carbine/Carbine.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	settings.B_SPREAD = 3; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.007); //Bullet gravity drop
 	settings.B_SPEED = 65; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 15; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 23; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 1.0f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::bullet_high_cal; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/ChargeLance/ChargeLance.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/ChargeLance/ChargeLance.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	settings.B_SPREAD = 1; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.0); //Bullet gravity drop
 	settings.B_SPEED = 145; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 15; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 20; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 50.0f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::railgun_lance; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/DartGun/DartGun.cfg
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/DartGun/DartGun.cfg
@@ -78,6 +78,7 @@ $inventory_name                         = Dart Gun
 $name                                   = dartgun
 @$scripts                               = DartGun.as;
                                           Metal.as;
+                                          NoPlayerCollision.as;
 f32 health                              = 10.0
 # looks & behaviour inside inventory
 $inventory_name                         = Dart Gun

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/GaussRifle/GaussRifle.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/GaussRifle/GaussRifle.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	settings.B_SPREAD = 0; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.005); //Bullet gravity drop
 	settings.B_SPEED = 150; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 13; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 20; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 1.50f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::railgun_lance; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/LeverRifle/LeverRifle.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/LeverRifle/LeverRifle.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	//settings.B_SPREAD = 0; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.006); //Bullet gravity drop
 	settings.B_SPEED = 75; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 15; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 20; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 2.5f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::bullet_high_cal; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/SAR/SAR.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/SAR/SAR.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	settings.B_SPREAD = 2; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.008); //Bullet gravity drop
 	settings.B_SPEED = 55; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 15; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 30; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 1.75f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::bullet_high_cal; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/SMG/SMG.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/SMG/SMG.as
@@ -7,7 +7,7 @@ void onInit(CBlob@ this)
 	//General
 	//settings.CLIP = 0; //Amount of ammunition in the gun at creation
 	settings.TOTAL = 30; //Max amount of ammo that can be in a clip
-	settings.FIRE_INTERVAL = 2; //Time in between shots
+	settings.FIRE_INTERVAL = 3; //Time in between shots
 	settings.RELOAD_TIME = 45; //Time it takes to reload (in ticks)
 	settings.AMMO_BLOB = "mat_pistolammo"; //Ammunition the gun takes
 
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	settings.B_SPREAD = 4; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.006); //Bullet gravity drop
 	settings.B_SPEED = 60; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 12; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 18; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 1.0f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::bullet_low_cal; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/Sniper/Sniper.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/Sniper/Sniper.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	settings.B_SPREAD = 0; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.001); //Bullet gravity drop
 	settings.B_SPEED = 130; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 10; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 15; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 3.0f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::bullet_high_cal; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/Uzi/Uzi.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Guns/Uzi/Uzi.as
@@ -16,7 +16,7 @@ void onInit(CBlob@ this)
 	settings.B_SPREAD = 6; //the higher the value, the more 'uncontrollable' bullets get
 	settings.B_GRAV = Vec2f(0, 0.007); //Bullet gravity drop
 	settings.B_SPEED = 60; //Bullet speed, STRONGLY AFFECTED/EFFECTS B_GRAV
-	settings.B_TTL = 12; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
+	settings.B_TTL = 13; //TTL = 'Time To Live' which determines the time the bullet lasts before despawning
 	settings.B_DAMAGE = 0.8f; //1 is 1 heart
 	settings.B_TYPE = HittersTC::bullet_low_cal; //Type of bullet the gun shoots | hitter
 

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/GatlingGun/GatlingGun.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/GatlingGun/GatlingGun.as
@@ -15,7 +15,7 @@ void onInit(CBlob@ this)
 	GunSettings settings = GunSettings();
 
 	settings.B_GRAV = Vec2f(0, 0.006); //Bullet Gravity
-	settings.B_TTL = 11; //Bullet Time to live
+	settings.B_TTL = 20; //Bullet Time to live
 	settings.B_SPEED = 70; //Bullet speed
 	settings.B_DAMAGE = 1.5f; //Bullet damage
 	settings.MUZZLE_OFFSET = Vec2f(-24, -1); //Where muzzle flash and bullet spawn
@@ -206,7 +206,7 @@ void Vehicle_onFire(CBlob@ this, VehicleInfo@ v, CBlob@ bullet, const u8 _unused
 
 	// Angle shittery
 	f32 angle = this.getAngleDegrees() + Vehicle_getWeaponAngle(this, v);
-	angle = angle * (this.isFacingLeft() ? -1 : 1);
+	angle *= this.isFacingLeft() ? -1 : 1;
 	angle += ((XORRandom(400) - 150) / 100.0f);
 
 	if (isServer())
@@ -286,6 +286,16 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
 	if (blob !is null) TryToAttachVehicle(this, blob);
+}
+
+bool isInventoryAccessible(CBlob@ this, CBlob@ forBlob)
+{
+	VehicleInfo@ v;
+	if (!this.get("VehicleInfo", @v)) return false;
+
+	CInventory@ inv = forBlob.getInventory();
+
+	return forBlob.getCarriedBlob() is null && (inv !is null ? inv.getItem(v.ammo_name) is null : true);
 }
 
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Howitzer/Howitzer.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Howitzer/Howitzer.as
@@ -217,6 +217,16 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 	if (blob !is null) TryToAttachVehicle(this, blob);
 }
 
+bool isInventoryAccessible(CBlob@ this, CBlob@ forBlob)
+{
+	VehicleInfo@ v;
+	if (!this.get("VehicleInfo", @v)) return false;
+
+	CInventory@ inv = forBlob.getInventory();
+
+	return forBlob.getCarriedBlob() is null && (inv !is null ? inv.getItem(v.ammo_name) is null : true);
+}
+
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
 	if (attached.hasTag("bomber")) return;

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/MachineGun/MachineGun.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/MachineGun/MachineGun.as
@@ -14,7 +14,7 @@ void onInit(CBlob@ this)
 	GunSettings settings = GunSettings();
 
 	settings.B_GRAV = Vec2f(0, 0.006); //Bullet Gravity
-	settings.B_TTL = 14; //Bullet Time to live
+	settings.B_TTL = 20; //Bullet Time to live
 	settings.B_SPEED = 70; //Bullet speed
 	settings.B_DAMAGE = 2.5f; //Bullet damage
 	settings.MUZZLE_OFFSET = Vec2f(-21, -4); //Where muzzle flash and bullet spawn
@@ -292,6 +292,16 @@ bool doesCollideWithBlob(CBlob@ this, CBlob@ blob)
 void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 {
 	if (blob !is null) TryToAttachVehicle(this, blob);
+}
+
+bool isInventoryAccessible(CBlob@ this, CBlob@ forBlob)
+{
+	VehicleInfo@ v;
+	if (!this.get("VehicleInfo", @v)) return false;
+
+	CInventory@ inv = forBlob.getInventory();
+
+	return forBlob.getCarriedBlob() is null && (inv !is null ? inv.getItem(v.ammo_name) is null : true);
 }
 
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Mortar/Mortar.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Mortar/Mortar.as
@@ -196,6 +196,16 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 	if (blob !is null) TryToAttachVehicle(this, blob);
 }
 
+bool isInventoryAccessible(CBlob@ this, CBlob@ forBlob)
+{
+	VehicleInfo@ v;
+	if (!this.get("VehicleInfo", @v)) return false;
+
+	CInventory@ inv = forBlob.getInventory();
+
+	return forBlob.getCarriedBlob() is null && (inv !is null ? inv.getItem(v.ammo_name) is null : true);
+}
+
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
 	if (attached.hasTag("bomber")) return;

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/RocketLauncher/RocketLauncher.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/RocketLauncher/RocketLauncher.as
@@ -210,6 +210,16 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 	if (blob !is null) TryToAttachVehicle(this, blob);
 }
 
+bool isInventoryAccessible(CBlob@ this, CBlob@ forBlob)
+{
+	VehicleInfo@ v;
+	if (!this.get("VehicleInfo", @v)) return false;
+
+	CInventory@ inv = forBlob.getInventory();
+
+	return forBlob.getCarriedBlob() is null && (inv !is null ? inv.getItem(v.ammo_name) is null : true);
+}
+
 void onAttach(CBlob@ this, CBlob@ attached, AttachmentPoint @attachedPoint)
 {
 	if (attached.hasTag("bomber")) return;


### PR DESCRIPTION
Various changes that may improve aspects of gun-meta and related.
- Bullet range is increased for most high caliber guns.
- Fixed an issue with bullets going backwards when the host is attached (e.g gatling gun in a bomber).
- The 'load' mechanic for stationary guns is cleaner.
- The sentry cannot be given ammunition by pilots when in the air.
- Sentry ammo capacity lowered to 500 rather than 1500.
- Fixed a problem with the gas extractor & dart gun colliding with players.
- Getting into certain seats within a small area is easier and won't be a hassle (e.g armored bomber with two attached turrets).
- Enabled backseat shooting.