### PR TITLE
Acid doesnt eat earth (Still eats ore)

### DIFF
--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/AcidGas/AcidGas.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/AcidGas/AcidGas.as
@@ -51,7 +51,7 @@ void onTick(CBlob@ this)
 			
 			TileType type = map.getTile(bpos).type;
 			
-			if (!isTileGlass(type) && !isTileBGlass(type) && type != CMap::tile_empty && type != CMap::tile_ground_back)
+			if (!isTileGlass(type) && !isTileBGlass(type) && !map.isTileGround(type) && type != CMap::tile_empty && type != CMap::tile_ground_back)
 			{
 				if (server && type != CMap::tile_bedrock)
 				{


### PR DESCRIPTION
Acid can no longer harm dirt, but can still eat stone ore and gold ore.
Personally im for this change since i don't like acid and think its too strong and had more countering options, but i am also probably one of the most peacefull players on tc so my opinion is a bit loose. Since other people requested this change im still gonna leave this push request here but im not fully certain and would like to hear more opinions.