### PR TITLE
Reduce ingot production of smelters from 1.5x/4x to 1x/2x

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/AutoForge/AutoForge.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/AutoForge/AutoForge.as
@@ -62,7 +62,7 @@ void onTick(CBlob@ this)
 			if (isServer())
 			{
 				CBlob@ mat = server_CreateBlob(matNamesResult[i], -1, this.getPosition());
-				mat.server_SetQuantity(1 + XORRandom(2));
+				mat.server_SetQuantity(1);
 				mat.Tag("justmade");
 				this.TakeBlob(matNames[i], matRatio[i]);
 			}

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/InductionFurnace/InductionFurnace.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/InductionFurnace/InductionFurnace.as
@@ -63,7 +63,7 @@ void onTick(CBlob@ this)
 			if (isServer())
 			{
 				CBlob @mat = server_CreateBlob(matNamesResult[i], -1, this.getPosition());
-				mat.server_SetQuantity(4);
+				mat.server_SetQuantity(2);
 				mat.Tag("justmade");
 				this.TakeBlob(matNames[i], matRatio[i]);
 				this.TakeBlob("mat_coal", coalRatio[i]);


### PR DESCRIPTION
Auto forge produces 1x ingots instead of 1.5x (previously random)
Induction smelter produces 2x instead of 4x

General nerf to slow down the easy of access to ingots and correspondingly money