### PR TITLE
Drug Nerf & Bug Fix

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Trader/Trader.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/NPC/Trader/Trader.as
@@ -141,7 +141,7 @@ void onInit(CBlob@ this)
 	addTokens(this); //colored shop icons
 
 	this.set_Vec2f("shop offset", Vec2f(0, 0));
-	this.set_Vec2f("shop menu size", Vec2f(4, 4));
+	this.set_Vec2f("shop menu size", Vec2f(4, 5));
 	this.set_string("shop description", name + " the Trader");
 	this.setInventoryName(name + " the Trader");
 	this.set_u8("shop icon", 25);

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Fiks/Fiksed.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Fiks/Fiksed.as
@@ -63,7 +63,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 
 	if (level > 1)
 	{
-		return damage / Maths::Min(level, 4);
+		return damage / Maths::Min(level, 2);
 	}
 
 	return damage;

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Stim/Stimed.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Stim/Stimed.as
@@ -33,7 +33,7 @@ void onTick(CBlob@ this)
 		RunnerMoveVars@ moveVars;
 		if (this.get("moveVars", @moveVars))
 		{
-			moveVars.walkFactor *= 2.00f + (true_level * 0.25f);
+			moveVars.walkFactor *= 2.00f + Maths::Min((true_level * 0.25f), 2);
 			moveVars.jumpFactor *= 1.85f;
 		}	
 		
@@ -55,15 +55,15 @@ void onTick(CBlob@ this)
 	// print("" + (1.00f / (level)));
 }
 
-f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
-{
-	f32 true_level = this.get_f32("stimed");		
-	f32 level = 1.00f + true_level;
+//f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitterBlob, u8 customData)
+//{
+	//f32 true_level = this.get_f32("stimed");		
+	//f32 level = 1.00f + true_level;
 
-	if (level > 1)
-	{
-		return damage / Maths::Min(level + 1, 4);
-	}
+	//if (level > 1)
+	//{
+		//return damage / Maths::Min(level, 2);
+	//}
 	
-	return damage;
-}
+	//return damage;
+//}


### PR DESCRIPTION
-Removed stims damage deduction, why does it reduce damage anyway domino and fiks already do, and it just allowed people to massively stack their damage reduction and be nearly invincible.
-Capped stims speed boost, no more flying.
-Reduced Fik's damage decrease.

Someone else dealt with the health increasing of fiks and domino so I don't have to do that here.

BUG FIX
expanded the trader's inventory for an easy fix, since it was reported to be too small and leave items floating.