### PR TITLE
Dark kudzu

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/FleshHit.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/FleshHit.as
@@ -198,8 +198,6 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		}
 	}
 	
-	if (this.get_f32("crak_effect") > 0) dmg *= 0.30f;
-	
 	this.Damage(dmg, hitterBlob);
 
 	f32 gibHealth = getGibHealth(this);

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Crak/Crak_Effect.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Crak/Crak_Effect.as
@@ -75,8 +75,8 @@ void onTick(CBlob@ this)
 		RunnerMoveVars@ moveVars;
 		if (this.get("moveVars", @moveVars))
 		{
-			moveVars.walkFactor *= 2.00f - (withdrawal * 1.50f);
-			moveVars.jumpFactor *= 2.50f - (withdrawal * 2.00f);
+			moveVars.walkFactor *= 1.50f - (withdrawal * 1.00f);
+			moveVars.jumpFactor *= 1.75f - (withdrawal * 1.25f);
 			
 			if (true_level > 3.00f)
 			{

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Domino/Domino.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Domino/Domino.as
@@ -23,7 +23,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (caller !is null)
 		{
 			if (!caller.hasScript("Dominoed.as")) caller.AddScript("Dominoed.as");
-			caller.set_f32("dominoed", 5);
+			caller.add_f32("dominoed", 5);
 			
 			if (isServer())
 			{

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Domino/Dominoed.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Domino/Dominoed.as
@@ -45,8 +45,8 @@ void onTick(CBlob@ this)
 		RunnerMoveVars@ moveVars;
 		if (this.get("moveVars", @moveVars))
 		{
-			moveVars.walkFactor *= 1.50f * modifier;
-			moveVars.jumpFactor *= 1.50f * modifier;
+			moveVars.walkFactor *= 1.20f * modifier;
+			moveVars.jumpFactor *= 1.20f * modifier;
 		}	
 				
 		if (modifier >= 1)

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Foof/Foofed.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Drugs/Foof/Foofed.as
@@ -44,7 +44,7 @@ void MegaHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ h
 
 	// print("megahit");
 	
-	f32 true_level = this.get_f32("foofed");		
+	f32 true_level = Maths::Min(this.get_f32("foofed"), 5);
 	f32 level = 1.00f + true_level;
 
 	// print("" + level);

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/AcidGas/AcidGas.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/AcidGas/AcidGas.as
@@ -51,7 +51,8 @@ void onTick(CBlob@ this)
 			
 			TileType type = map.getTile(bpos).type;
 			
-			if (!isTileGlass(type) && !isTileBGlass(type)  && !map.isTileGround(type) && type != CMap::tile_goldingot && type != CMap::tile_mithrilingot && type != CMap::tile_empty && type != CMap::tile_ground_back)
+			if (!isTileGlass(type) && !isTileBGlass(type) && type != CMap::tile_goldingot && type != CMap::tile_mithrilingot && 
+				type != CMap::tile_empty && type != CMap::tile_ground_back  && type != CMap::tile_ground_d0)
 			{
 				if (server && type != CMap::tile_bedrock)
 				{

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/FireGas/FireGas.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Gases/FireGas/FireGas.as
@@ -31,7 +31,7 @@ void onTick(CBlob@ this)
 			Vec2f bpos = pos + Vec2f(XORRandom(64) - 32, XORRandom(16));
 			
 			TileType t = map.getTile(bpos).type;
-			if (t != CMap::tile_castle_d0 && t != CMap::tile_ground_d0 && (XORRandom(100) < 50 ? true : t != CMap::tile_ground_d1))
+			if (t != CMap::tile_ground_d0 && (XORRandom(100) < 50 ? true : t != CMap::tile_ground_d1))
 			{
 				map.server_DestroyTile(bpos, 1, this);
 			}
@@ -63,7 +63,7 @@ void onCollision(CBlob@ this, CBlob@ blob, bool solid)
 			Vec2f bpos = pos + Vec2f(XORRandom(48) - 24, XORRandom(48) - 24);
 			TileType t = map.getTile(bpos).type;
 			
-			if (t != CMap::tile_castle_d0 && t != CMap::tile_ground_d0 && (XORRandom(100) < 50 ? true : t != CMap::tile_ground_d1))
+			if (t != CMap::tile_ground_d0 && (XORRandom(100) < 50 ? true : t != CMap::tile_ground_d1))
 			{
 				if (server)
 				{

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Kudzu/KudzuCommon.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Kudzu/KudzuCommon.as
@@ -180,11 +180,17 @@ void MutateTick(CBlob@ this)
 		//print(this.getHealth() + "");
 		this.server_Heal(0.1f);
 	}
-	if (this.hasTag("Mut_Mutating"))
+	if (this.get_u8("MutateMax") <= 70)
 	{
-		Random@ rand = Random(getGameTime());
-		int r = rand.NextRanged(300);
-		if (r == 0)
+		if (this.hasTag("Mut_Mutating"))
+		{
+			int r = XORRandom(this.get_f32("MutationTime")*0.5);
+			if (r <= 50)
+			{
+				Mutate(this);
+			}
+		}
+		else if (getGameTime() >= this.get_f32("NextMutate"))
 		{
 			Mutate(this);
 		}
@@ -273,43 +279,99 @@ void ApplyResistanceMutations(CBlob@ this, CBlob@ child) //Applies mutations to 
 	}
 }
 
-void Mutate(CBlob@ this)
+void Mutate(CBlob@ this, int hash = 0)
 {
-	CParticle@ particle = ParticleAnimated("SmallSmoke", this.getPosition(), Vec2f(0, 0), 0, 1.0f, 2, 0.0f, false);
-	if (particle != null)
-	{
-		particle.Z = 500;
-	}
+	this.set_f32("NextMutate", this.get_f32("MutationTime")+getGameTime());
 
+	if (hash != 0)
+	{
+		u8 mutChance = this.get_u8("MutationChance");
+		switch(hash)
+		{
+			case -661490310:	// mithrilingot
+				this.set_f32("MutationTime", this.get_f32("MutationTime") * 0.9);
+				this.add_u8("MutationChance", 1);
+				break;
 
-	Random@ rand = Random(getGameTime() + this.getPosition().x); //Randomness is time and position dependent, 
-	//technicly 2 of em in the same coloum mutated at the exact same time would get the same mutation
-	int r = rand.NextRanged(20);
-	if (r < 1 && !this.hasTag("Mut_Mutating")) //Possibly the most dangerous mutation, (At first slot to reduce the chance of getting it with other mutations)
-	{
-		this.Tag("Mut_Mutating");
+			case -1288560969:	// mithril
+				if (!this.hasTag("Mut_RadiationResistance") && mutChance < XORRandom(50)) this.Tag("Mut_RadiationResistance");
+				break;
+
+			case -989285105:	// mithrilenriched
+				if (!this.hasTag("Mut_RadiationResistance")) this.Tag("Mut_RadiationResistance");
+				this.add_u8("MutationChance", 10);
+				break;
+
+			case 1074492747:	// dirt
+				if (!this.hasTag("Mut_Regeneration") && mutChance < XORRandom(50)) this.Tag("Mut_Regeneration");
+				else Mutate_ExpansionBehavior(this);
+				break;
+
+			case -1326479778:	// oil
+				if (!this.hasTag("Mut_FireResistance") && mutChance < XORRandom(60))
+				{
+					this.Tag("Mut_FireResistance");
+					this.Untag(spread_fire_tag);
+					this.RemoveScript("IsFlammable.as");
+				}
+				break;
+
+			case -123101143:	// meat
+			case 336243301:		// steak
+				if (mutChance < XORRandom(50)) Mutate_DamageBehavior(this);
+				break;
+
+			case -1370030172:	// gold ore
+				if (!this.hasTag("Mut_Gold") && mutChance < XORRandom(40)) this.Tag("Mut_Gold");
+				break;
+
+			case -617913447:	// sulphur
+				if (!this.hasTag("Mut_Explosive") && mutChance < XORRandom(40)) this.Tag("Mut_Explosive");
+				break;
+
+			case 389592510:		// badger
+				if (!this.hasTag("Mut_Badgers") && mutChance < XORRandom(60)) this.Tag("Mut_Badgers");
+				break;
+		}
 	}
-	else if (r < 5)
+	else
 	{
-		Mutate_SurvivabilityBahvior(this, rand);
-	}
-	else if (r < 10)
-	{
-		Mutate_DamageBehavior(this, rand);
-	}
-	else if (r < 15)
-	{
-		Mutate_ExpansionBehavior(this, rand);
-	}
-	else if (r < 20)
-	{
-		Mutate_UpgradeBehavior(this, rand);
+		this.add_u8("MutateMax", 1);
+		CParticle@ particle = ParticleAnimated("SmallSmoke", this.getPosition(), Vec2f(0, 0), 0, 1.0f, 2, 0.0f, false);
+		if (particle != null)
+		{
+			particle.Z = 500;
+		}
+
+		if (this.get_u8("MutationChance") < XORRandom(15)) return;
+
+		int r = XORRandom(20);
+		if (r < 1 && !this.hasTag("Mut_Mutating")) //Possibly the most dangerous mutation, (At first slot to reduce the chance of getting it with other mutations)
+		{
+			this.Tag("Mut_Mutating");
+		}
+		else if (r < 5)
+		{
+			Mutate_SurvivabilityBahvior(this);
+		}
+		else if (r < 10)
+		{
+			Mutate_DamageBehavior(this);
+		}
+		else if (r < 15)
+		{
+			Mutate_ExpansionBehavior(this);
+		}
+		else if (r < 20)
+		{
+			Mutate_UpgradeBehavior(this);
+		}
 	}
 }
 
-void Mutate_SurvivabilityBahvior(CBlob@ this, Random@ rand)
+void Mutate_SurvivabilityBahvior(CBlob@ this)
 {
-	int r = rand.NextRanged(4);
+	int r = XORRandom(4);
 	if (r < 1 && !this.hasTag("Mut_NoLight"))
 	{
 		this.SetLight(false);
@@ -329,15 +391,11 @@ void Mutate_SurvivabilityBahvior(CBlob@ this, Random@ rand)
 	{
 		this.Tag("Mut_RadiationResistance");
 	}
-	else
-	{
-		//NOTHING, for now
-	}
 }
 
-void Mutate_DamageBehavior(CBlob@ this, Random@ rand)
+void Mutate_DamageBehavior(CBlob@ this)
 {
-	int r = rand.NextRanged(4);
+	int r = XORRandom(4);
 	
 	if (r < 1)
 	{
@@ -358,9 +416,9 @@ void Mutate_DamageBehavior(CBlob@ this, Random@ rand)
 	}
 }
 
-void Mutate_ExpansionBehavior(CBlob@ this, Random@ rand)
+void Mutate_ExpansionBehavior(CBlob@ this)
 {	
-	int r = rand.NextRanged(5);
+	int r = XORRandom(5);
 	if (r < 1 && !this.hasTag("Mut_IgnoreBGlass"))
 	{
 		this.Tag("Mut_IgnoreBGlass");
@@ -387,9 +445,9 @@ void Mutate_ExpansionBehavior(CBlob@ this, Random@ rand)
 	}
 }
 
-void Mutate_UpgradeBehavior(CBlob@ this, Random@ rand)
+void Mutate_UpgradeBehavior(CBlob@ this)
 {	
-	int r = rand.NextRanged(5);
+	int r = XORRandom(5);
 	if (r < 1 && !this.hasTag("Mut_Explosive")) //Honestly a negative mutation, since the explosion also damages the plant and causes chain reactions
 	{
 		this.Tag("Mut_Explosive");

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Kudzu/KudzuCore.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Kudzu/KudzuCore.as
@@ -11,6 +11,7 @@ void onInit(CBlob @ this)
 	this.getShape().SetRotationsAllowed(false);
 
 	this.Tag("builder always hit");
+	this.Tag("nature");
 	this.Tag(spread_fire_tag);
 
 	Vec2f[] sprouts = {};
@@ -23,6 +24,10 @@ void onInit(CBlob @ this)
 	this.SetLightColor(SColor(255, 155, 255, 0));
 
 	//Base stats
+	this.set_u8("MutationChance", 10);
+	this.set_u8("MutateMax", 0); // overtime mutations
+	this.set_f32("NextMutate", getGameTime() + (1800*3)); // time til next mutation
+	this.set_f32("MutationTime", (1800*5));
 	this.set_u8("MaxSprouts", 10);
 	this.set_f32("UpgradeSpeed", 1);
 	this.set_u8("DamageMod", 1); //Base multiplier on 0.125
@@ -54,12 +59,32 @@ const u32 RECHARGETIME = 18000; // 30 = 1 second, 1800 = 1 minute, this is 10 mi
 void GetButtonsFor(CBlob@ this, CBlob@ caller) //Mutate button
 {
 	CBlob@ carried = caller.getCarriedBlob();
-
-	if (carried != null && carried.getName() == "mat_mithrilingot")
+	if (carried != null)
 	{
-		CBitStream params;
-		params.write_u16(caller.getNetworkID());
-		CButton@ button = caller.CreateGenericButton(23, Vec2f(0, 0), this, this.getCommandID("mutate"), "Mutate", params);
+		bool canMutate = false;
+		const int hash = carried.getName().getHash();
+		switch (hash)
+		{
+			case -661490310:	// mithrilingot
+			case -1288560969:	// mithril
+			case -989285105:	// mithrilenriched
+			case 1074492747:	// dirt
+			case -1326479778:	// oil
+			case -123101143:	// meat
+			case -1370030172:	// gold ore
+			case -617913447:	// sulphur
+			case 389592510:		// badger
+			case 336243301:		// steak
+				
+				canMutate = true;
+				break;
+		}
+		if (canMutate)
+		{
+			CBitStream params;
+			params.write_u16(caller.getNetworkID());
+			CButton@ button = caller.CreateGenericButton(23, Vec2f(0, 0), this, this.getCommandID("mutate"), "Mutate", params);
+		}
 	}
 }
 
@@ -71,23 +96,43 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params) //Mutate command
 		if (caller !is null)
 		{
 			CBlob@ carried = caller.getCarriedBlob();
-			if (carried !is null && carried.getName() == "mat_mithrilingot")
+			int matReq = 0;
+			const int hash = carried.getName().getHash();
+
+			if (carried !is null)
 			{
-				if (carried.getQuantity() >= 10)
+				switch(hash)
 				{
-					
-					int remain = carried.getQuantity() - 10;
-					if (remain > 0)
-					{
-						carried.server_SetQuantity(remain);
-					}
-					else
-					{
-						carried.Tag("dead");
-						carried.server_Die();
-					}
+					case -661490310:	matReq = 10;	break;	// mithrilingot
+					case -989285105:	matReq = 10;	break;	// mithrilenriched
+					case -1288560969:	matReq = 200; 	break;	// mithril
+					case 1074492747:	matReq = 500; 	break;	// dirt
+					case -1326479778:	matReq = 50; 	break;	// oil
+					case -123101143: 	matReq = 100;	break;	// meat
+					case -1370030172:	matReq = 250;	break;	// gold ore
+					case -617913447:	matReq = 250;	break;	// sulphur
+					case 389592510:		matReq = 1;	break;	// badger
+					case 336243301:		matReq = 1;	break;	// steak
+				}
+			}
+
+			if (carried.getQuantity() >= matReq)
+			{
+				int remain = carried.getQuantity() - matReq;
+				if (remain > 0)
+				{
+					carried.server_SetQuantity(remain);
+				}
+				else
+				{
+					carried.Tag("dead");
+					carried.server_Die();
+				}
+				if (hash == -661490310 || hash == -989285105)
+				{
 					Mutate(this);
 				}
+				Mutate(this, hash);
 			}
 		}
 	}

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Kudzu/KudzuHit.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Kudzu/KudzuHit.as
@@ -77,7 +77,6 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			break;
 			
 		case HittersTC::radiation:
-
 			dmg *= this.hasTag("Mut_RadiationResistance") ? 0.00f : 1.50f;
 			break;
 			

--- a/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Kudzu/KudzuHit.as
+++ b/TFlippy_TerritoryControl_Misc_Dev/Entities/Misc/Kudzu/KudzuHit.as
@@ -28,6 +28,7 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		case Hitters::spikes:
 		case Hitters::sword:
 		case Hitters::stab:
+		case Hitters::drill:
 			dmg *=  1.50f;
 			if (isClient())
 			{
@@ -36,17 +37,17 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 			break;
 
 		case Hitters::arrow:
-			dmg *= 0.20f;
+			dmg *= 1.00f;
 			break;
 			
 		case Hitters::bomb_arrow:
 		case Hitters::bomb:
-			dmg *= 0.25f;
+			dmg *= 1.25f;
 			break;
 
 		case Hitters::keg:
 		case Hitters::explosion:
-			dmg *= 0.25f;
+			dmg *= 1.25f;
 			break;
 
 		case Hitters::fire:
@@ -64,18 +65,19 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 		
 		// TC		
 		case HittersTC::bullet_low_cal:
-			dmg *= 0.33f;
+			dmg *= 0.66f;
 			break;
 			
 		case HittersTC::bullet_high_cal:
-			dmg *= 0.50f;
+			dmg *= 1.00f;
 			break;
 			
 		case HittersTC::shotgun:
-			dmg *= 0.10f;
+			dmg *= 0.75f;
 			break;
 			
 		case HittersTC::radiation:
+
 			dmg *= this.hasTag("Mut_RadiationResistance") ? 0.00f : 1.50f;
 			break;
 			

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Dragonfriend/Fumes/Fumes.as
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/Dragonfriend/Fumes/Fumes.as
@@ -22,7 +22,7 @@ void onCommand(CBlob@ this, u8 cmd, CBitStream @params)
 		if (caller !is null)
 		{		
 			if (!caller.hasScript("Fumes_Effect.as")) caller.AddScript("Fumes_Effect.as");			
-			caller.add_f32("fumes_effect", 1);
+			caller.add_f32("fumes_effect", 2);
 			
 			caller.set_u32("nextDragonFireball", getGameTime());
 

--- a/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/SwagLag/Dew/Dew_Effect.as
+++ b/TFlippy_TerritoryControl_Patreon_Dev/Structures/Altar/SwagLag/Dew/Dew_Effect.as
@@ -127,7 +127,7 @@ void onTick(CBlob@ this)
 	
 		// print("" + modifier);
 		// print("" + level / max_time);
-		this.set_f32("dew_effect", Maths::Max(0, this.get_f32("dew_effect") - (0.002f)));
+		this.set_f32("dew_effect", Maths::Max(0, this.get_f32("dew_effect") - (0.001f)));
 	}
 	
 	// print("" + true_level);

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/DrugLab/DrugLab.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/DrugLab/DrugLab.as
@@ -381,9 +381,9 @@ void React(CBlob@ this)
 				{
 					mithril_blob.server_SetQuantity(Maths::Max(mithril_blob.getQuantity() - 50, 0));
 					acid_blob.server_SetQuantity(Maths::Max(acid_blob.getQuantity() - 25, 0));
-					Material::createFor(this, "domino", 3 + XORRandom(6));
+					Material::createFor(this, "domino", 6 + XORRandom(6));
 					Material::createFor(this, "mat_mithrilenriched", XORRandom(10));
-					Material::createFor(this, "mat_fuel", XORRandom(40));
+					Material::createFor(this, "mat_fuel", 20 + XORRandom(20));
 				}
 
 				ShakeScreen(20.0f, 15, this.getPosition());


### PR DESCRIPTION
- Crak no longer has damage reduction
- Crak and Domino speed buff nerfed
- Druglab gives more domino from the risky domino recipe
- Foofed AoE capped
- Fumes and Dew now last 2x longer
- Acid now damages dirt, but doesn't fully destroy it
- Blazethrower now destroys castleblocks
- Kudzu Rework:
- Kudzu can take damage from radiation
- Kudzu can mutate radiation resistance
- Kudzu no longer has extreme bulletResistance/explosiveResistance
- Can feed kudzucores a variety of items to have a chance to get a specific mutation:
- Meat, steak, sulphur, gold ore, badger, oil, dirt, mithril ore/ingot/enriched
- Mithril ingot and enriched mithril increases overtime mutation, go figure out the rest!