### PR TITLE
Ingot LagFix

### DIFF
--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_CopperIngot.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_CopperIngot.cfg
@@ -82,4 +82,4 @@ u8 inventory_icon_frame_width          = 16
 u8 inventory_icon_frame_height         = 16
 u8 inventory_used_width                = 1
 u8 inventory_used_height               = 1
-u8 inventory_max_stacks                = 2
+u8 inventory_max_stacks                = 1

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_GoldIngot.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_GoldIngot.cfg
@@ -82,4 +82,4 @@ u8 inventory_icon_frame_width          = 16
 u8 inventory_icon_frame_height         = 16
 u8 inventory_used_width                = 1
 u8 inventory_used_height               = 1
-u8 inventory_max_stacks                = 2
+u8 inventory_max_stacks                = 1

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_Ingot.as
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_Ingot.as
@@ -8,6 +8,6 @@ void onInit(CBlob@ this)
 		}
 	}
 
-	this.maxQuantity = 50;
+	this.maxQuantity = 100;
 	this.getCurrentScript().runFlags |= Script::remove_after_this;
 }

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_IronIngot.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_IronIngot.cfg
@@ -83,4 +83,4 @@ u8 inventory_icon_frame_width          = 16
 u8 inventory_icon_frame_height         = 16
 u8 inventory_used_width                = 1
 u8 inventory_used_height               = 1
-u8 inventory_max_stacks                = 2
+u8 inventory_max_stacks                = 1

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_MithrilIngot.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_MithrilIngot.cfg
@@ -82,4 +82,4 @@ u8 inventory_icon_frame_width          = 16
 u8 inventory_icon_frame_height         = 16
 u8 inventory_used_width                = 1
 u8 inventory_used_height               = 1
-u8 inventory_max_stacks                = 2
+u8 inventory_max_stacks                = 1

--- a/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_SteelIngot.cfg
+++ b/TFlippy_TerritoryControl_Core_Dev/Entities/Materials/Metals/Material_SteelIngot.cfg
@@ -82,4 +82,4 @@ u8 inventory_icon_frame_width          = 16
 u8 inventory_icon_frame_height         = 16
 u8 inventory_used_width                = 1
 u8 inventory_used_height               = 1
-u8 inventory_max_stacks                = 2
+u8 inventory_max_stacks                = 1


### PR DESCRIPTION
- Only 1 stack per slot, 100 ingots per stack, as opposed to 2 and 50
- Will reduce lag from ingots by 50%