### PR TITLE
Farm lag

### DIFF
--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/CrystalTree/CrystalTree.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/CrystalTree/CrystalTree.as
@@ -21,11 +21,23 @@ void onDie(CBlob@ this)
 	
 	if (isServer())
 	{
-		for (int i = 0; i < (5 + XORRandom(15)); i++)
+		for (int i = 0; i < (7 + XORRandom(7)); i++)
 		{
-			CBlob@ blob = server_CreateBlob(XORRandom(3) == 0 ? "mat_mithril" : "mat_matter", this.getTeamNum(), this.getPosition() - Vec2f(0, XORRandom(64)));
-			blob.server_SetQuantity(5 + XORRandom(10));
-			blob.setVelocity(Vec2f(XORRandom(4) - 2, -2 - XORRandom(3)));
+			{
+				CBlob@ blob = server_CreateBlob("mat_mithril", this.getTeamNum(), this.getPosition() - Vec2f(0, XORRandom(64)));
+				blob.server_SetQuantity(5 + XORRandom(10));
+				blob.setVelocity(Vec2f(XORRandom(4) - 2, -2 - XORRandom(3)));
+			}
+			{
+				CBlob@ blob = server_CreateBlob("mat_matter", this.getTeamNum(), this.getPosition() - Vec2f(0, XORRandom(64)));
+				blob.server_SetQuantity(35 + XORRandom(15));
+				blob.setVelocity(Vec2f(XORRandom(4) - 2, -2 - XORRandom(3)));
+			}
+			{
+				CBlob@ blob = server_CreateBlob("mat_wood", this.getTeamNum(), this.getPosition() - Vec2f(0, XORRandom(64)));
+				blob.server_SetQuantity(15 + XORRandom(10));
+				blob.setVelocity(Vec2f(XORRandom(4) - 2, -2 - XORRandom(3)));
+			}
 		}
 	}
 }
@@ -36,15 +48,6 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	{ 
 		this.getSprite().PlaySound("dig_stone.ogg", 0.8f, 1.2f);
 		this.getSprite().PlaySound("TreeChop" + (1 + XORRandom(3)) + ".ogg", 1.0f, 1.0f);
-	}
-	
-	if (isServer())
-	{
-		if (hitterBlob !is null)
-		{
-			MakeMat(hitterBlob, worldPoint, "mat_matter", 3 + XORRandom(15));	
-			MakeMat(hitterBlob, worldPoint, "mat_wood", 2 + XORRandom(10));	
-		}
 	}
 	
 	return damage;

--- a/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/DeadTree/DeadTree.as
+++ b/TFlippy_TerritoryControl_Characters_Dev/Entities/Nature/DeadTree/DeadTree.as
@@ -16,11 +16,18 @@ void onDie(CBlob@ this)
 	
 	if (isServer())
 	{
-		for (int i = 0; i < (5 + XORRandom(5)); i++)
+		for (int i = 0; i < 5; i++)
 		{
-			CBlob@ blob = server_CreateBlob("mat_wood", this.getTeamNum(), this.getPosition() - Vec2f(0, XORRandom(64)));
-			blob.server_SetQuantity(1 + XORRandom(4));
-			blob.setVelocity(Vec2f(XORRandom(4) - 2, -2 - XORRandom(3)));
+			{
+				CBlob@ blob = server_CreateBlob("mat_wood", this.getTeamNum(), this.getPosition() - Vec2f(0, XORRandom(64)));
+				blob.server_SetQuantity(30 + XORRandom(50));
+				blob.setVelocity(Vec2f(XORRandom(4) - 2, -2 - XORRandom(3)));
+			}
+			{
+				CBlob@ blob = server_CreateBlob("mat_coal", this.getTeamNum(), this.getPosition() - Vec2f(0, XORRandom(64)));
+				blob.server_SetQuantity(10 + XORRandom(10));
+				blob.setVelocity(Vec2f(XORRandom(4) - 2, -2 - XORRandom(3)));
+			}
 		}
 	}
 }
@@ -32,18 +39,6 @@ f32 onHit(CBlob@ this, Vec2f worldPoint, Vec2f velocity, f32 damage, CBlob@ hitt
 	if (isClient())
 	{ 
 		this.getSprite().PlaySound("TreeChop" + (1 + XORRandom(3)) + ".ogg", 1.0f, 1.0f);
-	}
-	
-	if (isServer())
-	{
-		if (hitterBlob !is null)
-		{
-			if(hitterBlob.getName() != "acidgas")//way too stronk and ends up nuking the server with mat_coal
-			{
-				MakeMat(hitterBlob, worldPoint, "mat_coal", 1 + XORRandom(3));
-				MakeMat(hitterBlob, worldPoint, "mat_wood", 3 + XORRandom(10));	
-			}
-		}
 	}
 	
 	return damage;

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Food/Eatable.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/Food/Eatable.as
@@ -30,7 +30,7 @@ void onInit(CBlob@ this)
 			break;
 		// grain
 		case -1788840884:
-			this.maxQuantity = 10;
+			this.maxQuantity = 20;
 			break;
 		// ratfood
 		case 1197821324:

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/GasExtractor/GasExtractor.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/GasExtractor/GasExtractor.as
@@ -39,7 +39,7 @@ void onTick(CBlob@ this)
 
 			if ((!rmb && point.isKeyJustPressed(key_action1)) || (!lmb && point.isKeyJustPressed(key_action2)))
 			{
-				this.getSprite().PlaySound("/gasextractor_start.ogg");
+				this.getSprite().PlaySound("/gasextractor_start.ogg", 0.2f);
 			}
 			else if (lmb || rmb)
 			{
@@ -84,9 +84,9 @@ void onTick(CBlob@ this)
 									{
 										if (isServer())
 										{
-											if (blob.getName() == "mustard" || blob.getName() == "methane")
+											if (blob.getName() == "falloutgas")
 											{
-												MakeMat(holder, this.getPosition(), "mat_" + blob.getName(), 1 + XORRandom(5));
+												MakeMat(holder, this.getPosition(), "mat_" + "mithril", 3 + XORRandom(5));
 											}
 											else
 											{
@@ -95,11 +95,11 @@ void onTick(CBlob@ this)
 											blob.server_Die();
 										}
 
-										sprite.PlaySound("/gasextractor_load.ogg");
+										sprite.PlaySound("/gasextractor_load.ogg", 0.2f);
 									}
 									else if (blob.canBePickedUp(holder) && !holder.getInventory().isFull())
 									{
-										sprite.PlaySound("/gasextractor_load.ogg");
+										sprite.PlaySound("/gasextractor_load.ogg", 0.2f);
 										if (isServer()) holder.server_PutInInventory(blob);
 									}
 								}

--- a/TFlippy_TerritoryControl_Items_Dev/Entities/Items/MysteryBox/MysteryBox.as
+++ b/TFlippy_TerritoryControl_Items_Dev/Entities/Items/MysteryBox/MysteryBox.as
@@ -72,7 +72,10 @@ void onInit(CBlob@ this)
 
 void GetButtonsFor(CBlob@ this, CBlob@ caller)
 {
-	caller.CreateGenericButton(12, Vec2f(0, 0), this, this.getCommandID("box_unpack"), "Unpack");
+	if (caller !is null && (caller.getPosition() - this.getPosition()).Length() <= 48)
+	{
+		caller.CreateGenericButton(12, Vec2f(0, 0), this, this.getCommandID("box_unpack"), "Unpack");
+	}
 }
 
 void onCommand(CBlob@ this, u8 cmd, CBitStream @params)

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Treecapitator/Treecapitator.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Treecapitator/Treecapitator.as
@@ -10,16 +10,7 @@ void onInit(CBlob @ this)
 	// this.Tag("ignore extractor");
 	this.Tag("builder always hit");
 
-	this.getCurrentScript().tickFrequency = 15;
-
-	CSprite@ sprite = this.getSprite();
-	if (sprite !is null)
-	{
-		sprite.SetEmitSound("Treecapicator_Idle.ogg");
-		sprite.SetEmitSoundVolume(0.10f);
-		sprite.SetEmitSoundSpeed(1.0f);
-		sprite.SetEmitSoundPaused(false);
-	}
+	this.getCurrentScript().tickFrequency = 240;
 }
 
 void onTick(CBlob@ this)
@@ -42,7 +33,18 @@ void onTick(CBlob@ this)
 			{
 				string bname = b.getName();
 
-				if (b.hasTag("tree"))
+				if (bname == "grain" || bname == "pumpkin" || bname == "log" || bname == "ganjapod" )
+				{
+					this.server_PutInInventory(b);
+				}
+				else if (bname == "grain_plant" || bname == "pumpkin_plant" || bname == "ganja_plant")
+				{
+					if (b.hasTag("has pumpkin") || b.hasTag("has pod") || b.hasTag("has grain"))
+					{
+						this.server_Hit(b, b.getPosition(), Vec2f(0, 0), 2.00f, Hitters::saw);
+					}
+				}
+				else if (b.hasTag("tree"))
 				{
 					TreeVars@ tree;
 					b.get("TreeVars", @tree);
@@ -50,19 +52,8 @@ void onTick(CBlob@ this)
 					{
 						if (tree.height == tree.max_height)
 						{
-							this.server_Hit(b, b.getPosition(), Vec2f(0, 0), 1.00f, Hitters::saw);
+							this.server_Hit(b, b.getPosition(), Vec2f(0, 0), 4.00f, Hitters::saw);
 						}
-					}
-				}
-				else if (bname == "log" || bname == "pumpkin" || bname == "grain" || bname == "ganjapod" )
-				{
-					this.server_PutInInventory(b);
-				}
-				else if (bname == "pumpkin_plant" || bname == "ganja_plant" || bname == "grain_plant" )
-				{
-					if (b.hasTag("has pumpkin") || b.hasTag("has pod") || b.hasTag("has grain"))
-					{
-						this.server_Hit(b, b.getPosition(), Vec2f(0, 0), 1.00f, Hitters::saw);
 					}
 				}
 				else if (!b.getShape().isStatic())
@@ -77,4 +68,9 @@ void onTick(CBlob@ this)
 bool canBePickedUp(CBlob@ this, CBlob@ byBlob)
 {
 	return false;
+}
+
+bool isInventoryAccessible(CBlob@ this, CBlob@ forBlob)
+{
+	return forBlob !is null && (forBlob.getName() == "extractor" || forBlob.getName() == "filterextractor" || (forBlob.getPosition() - this.getPosition()).Length() <= 64);
 }

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Treecapitator/Treecapitator.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/Treecapitator/Treecapitator.cfg
@@ -64,7 +64,7 @@ $attachment_factory                    = generic_attachment
 $inventory_factory                         = generic_inventory
 @$inventory_scripts                               = 
 u8 inventory_slots_width                          = 3
-u8 inventory_slots_height                         = 2
+u8 inventory_slots_height                         = 1
 $inventory_name                                   = Treecapitator
 
 # general
@@ -78,7 +78,7 @@ $name                                      = treecapitator
 											 SimpleSupport.as;
 											 TileBackground.as;
 											 GenericOnStatic.as;
-f32_health                                 = 5.0
+f32_health                                 = 1.5
 # looks & behaviour inside inventory
 $inventory_name                            = Treecapitator
 $inventory_icon                            = Treecapitator.png

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/MethaneCollector/MethaneCollector.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/MethaneCollector/MethaneCollector.as
@@ -10,7 +10,7 @@ void onInit(CBlob@ this)
 
 	this.Tag("builder always hit");
 
-	this.getCurrentScript().tickFrequency = 150;
+	this.getCurrentScript().tickFrequency = 300;
 
 	CSprite@ sprite = this.getSprite();
 	sprite.SetEmitSound("MethaneCollector_Loop.ogg");
@@ -27,11 +27,11 @@ void onTick(CBlob@ this)
 
 		if (storage !is null)
 		{
-			MakeMat(storage, this.getPosition(), "mat_methane", 2 + XORRandom(3));
+			MakeMat(storage, this.getPosition(), "mat_methane", 4 + XORRandom(5));
 		}
 		else if (this.getInventory().getCount("mat_methane") < 100)
 		{
-			MakeMat(this, this.getPosition(), "mat_methane", 2 + XORRandom(3));
+			MakeMat(this, this.getPosition(), "mat_methane", 4 + XORRandom(5));
 		}
 	}
 }


### PR DESCRIPTION
- Increase stack size of grain from 10 to 20
- Buttons only appear when 8 blocks away instead of when I'm 1000 blocks away and still feel lag when I press E
- Made Tree Capitators and Methane Collectors less laggy
- treecapitators have less health so that you can dismantle them easier
- Fixed dupe/lag/crash exploit of dead/crystal trees