### PR TITLE
Less Laggy Sentry

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.cfg
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.cfg
@@ -58,13 +58,7 @@ $attachment_factory                    = box2d_attachment
 @$attachment_points                    = PICKUP; 0; 8; 1; 0; 0;
                                          VEHICLE; 0; 4; 1; 0; 0;
 
-$inventory_factory                     = generic_inventory
-@$inventory_scripts                    = 
-u8 inventory_slots_width               = 1
-u8 inventory_slots_height              = 1
-$inventory_name                        = Requires Gatling Ammunition
-
-# general
+$inventory_factory                     = 
 
 $name                                  = sentry
 @$scripts                              = Metal.as;

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Zapper/Zapper.as
@@ -115,6 +115,7 @@ void onTick(CBlob@ this)
 			{
 				CBlob@ b = blobsInRadius[i];
 				u8 team = b.getTeamNum();
+				if (team == myTeam || map.rayCastSolid(this.getPosition(), b.getPosition())) continue;
 
 				for (uint s = 0; s < spawns.length; s++)
 				{
@@ -124,8 +125,7 @@ void onTick(CBlob@ this)
 					    !map.rayCastSolid(this.getPosition(), b.getPosition())) return;
 				}
 
-				if (myTeam == 250 && b.get_u8("deity_id") == Deity::foghorn) continue;
-				if (team != myTeam && b.hasTag("flesh") && !b.hasTag("dead") && !map.rayCastSolid(this.getPosition(), b.getPosition()))
+				if (b.hasTag("flesh") && !b.hasTag("dead"))
 				{
 					f32 dist = (b.getPosition() - this.getPosition()).Length();
 					if (dist < s_dist)
@@ -145,11 +145,11 @@ void onTick(CBlob@ this)
 				CPlayer@ _target = target.getPlayer();
 				if (host !is null && _target is host) //recognizes host and changes team
 				{
-					this.server_setTeamNum(_target.getTeamNum());
+					this.server_setTeamNum(_target.getBlob().getTeamNum());
 					return;
 				}
+				Zap(this, target);
 			}
-			Zap(this, target);
 		}
 	}
 }


### PR DESCRIPTION
- Sentry now checks ammo as a number instead of a blob, which results in less lag
- Sam/LWS now skips targets that cannot be seen
- Fixed zapper/sentry no change team

[YES] - Have I tested it out in localhost
[YES] - Have I tested it out in a dedicated server