### PR TITLE
Reduced Kudzu Price

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Nursery/Nursery.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Nursery/Nursery.as
@@ -90,9 +90,7 @@ void onInit(CBlob@ this)
 		ShopItem@ s = addShopItem(this, "Kudzu Core", "$kudzucore$", "kudzucore", "Creates a kudzu core a quickly spreading plant which slowy damages other things, Cannot be stored", true);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", 500);
 		AddRequirement(s.requirements, "blob", "mat_dirt", "Dirt", 200);
-		AddRequirement(s.requirements, "blob", "grain", "Grain", 1); 
-		AddRequirement(s.requirements, "blob", "mat_mithrilingot", "Mithril Ingot", 1);
-		//Requiring grain and a mithrilg ingot means its a lot harder to spawm since both of these ressources are harder to get on mass (instead of dirt wood and coins alone)
+		AddRequirement(s.requirements, "coin", "", "Coins", 100);
 		s.spawnNothing = true;
 	}
 }


### PR DESCRIPTION
I have not seen Kudzu used since roughly 1 week after the price nerf.
As the furnace production has been un-nerfed i would like to un-nerf kudzu as well to make it at least kinda usable again.

As such this replaces the 1 mithril ingot and 1 grain cost with 100 coins. You still need to construct the nursery and pay 500 wood and 200 dirt.