### PR TITLE
Nursery Recepie Changes

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Nursery/Nursery.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Nursery/Nursery.as
@@ -90,7 +90,9 @@ void onInit(CBlob@ this)
 		ShopItem@ s = addShopItem(this, "Kudzu Core", "$kudzucore$", "kudzucore", "Creates a kudzu core a quickly spreading plant which slowy damages other things, Cannot be stored", true);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", 500);
 		AddRequirement(s.requirements, "blob", "mat_dirt", "Dirt", 200);
-		AddRequirement(s.requirements, "coin", "", "Coins", 100);
+		AddRequirement(s.requirements, "blob", "grain", "Grain", 1); 
+		AddRequirement(s.requirements, "blob", "mat_mithrilingot", "Mithril Ingot", 1);
+		//Requiring grain and a mithrilg ingot means its a lot harder to spawm since both of these ressources are harder to get on mass (instead of dirt wood and coins alone)
 		s.spawnNothing = true;
 	}
 }

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Nursery/Nursery.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Nursery/Nursery.as
@@ -36,8 +36,7 @@ void onInit(CBlob@ this)
 	this.set_u8("shop icon", 15);
 	
 	{
-		ShopItem@ s = addShopItem(this, "Grain Seed", "$grainplant$", "grain_seed", "A common food source which can be used for various tasks.\nConvert grain into seeds.");
-		AddRequirement(s.requirements, "blob", "grain", "Grain", 1);
+		ShopItem@ s = addShopItem(this, "Grain Seed", "$grainplant$", "grain_seed", "A common food source which can be used for various tasks.");
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", 50);
 		AddRequirement(s.requirements, "coin", "", "Coins", 40);
 		s.customButton = true;
@@ -46,8 +45,15 @@ void onInit(CBlob@ this)
 		s.spawnNothing = true;
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Ganja Seed", "$ganjaplant$", "ganja_seed", "A plant which is known for its drug properties.\nConvert a ganja pod into a seed.", true);
-		AddRequirement(s.requirements, "blob", "ganjapod", "Ganja Pod", 1);
+		ShopItem@ s = addShopItem(this, "Grain Harvest", "$grainplant$", "grain_seed", "Convert grain into 1-3 seeds.");
+		AddRequirement(s.requirements, "blob", "grain", "Grain", 1);
+		s.customButton = true;
+		s.buttonwidth = 1;
+		s.buttonheight = 2;
+		s.spawnNothing = true;
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Ganja Seed", "$ganjaplant$", "ganja_seed", "A plant which is known for its drug properties.", true);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", 70);
 		AddRequirement(s.requirements, "coin", "", "Coins", 100);
 		s.customButton = true;
@@ -56,10 +62,22 @@ void onInit(CBlob@ this)
 		s.spawnNothing = true;
 	}
 	{
-		ShopItem@ s = addShopItem(this, "Pumpkin Seed", "$pumpkin$", "pumpkin_seed", "A large squash fun for festivities.\nAttempt to convert a pumpkin into a seed.", true);
-		AddRequirement(s.requirements, "blob", "pumpkin", "Pumpkin", 1);
+		ShopItem@ s = addShopItem(this, "Ganja Harvest", "$ganjaplant$", "ganja_seed", "Convert a ganja pod into a seed.", true);
+		AddRequirement(s.requirements, "blob", "ganjapod", "Ganja Pod", 1);
+		s.customButton = true;
+		s.buttonwidth = 1;
+		s.buttonheight = 2;
+		s.spawnNothing = true;
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Pumpkin Seed", "$pumpkin$", "pumpkin_seed", "A large squash fun for festivities.", true);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", 50);
 		AddRequirement(s.requirements, "coin", "", "Coins", 80);
+		s.spawnNothing = true;
+	}
+	{
+		ShopItem@ s = addShopItem(this, "Pumpkin Harvest", "$pumpkin$", "pumpkin_seed", "Convert a Pumpkin into its seed.", true);
+		AddRequirement(s.requirements, "blob", "pumpkin", "Pumpkin", 1);
 		s.spawnNothing = true;
 	}
 	{
@@ -90,9 +108,8 @@ void onInit(CBlob@ this)
 		ShopItem@ s = addShopItem(this, "Kudzu Core", "$kudzucore$", "kudzucore", "Creates a kudzu core a quickly spreading plant which slowy damages other things, Cannot be stored", true);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", 500);
 		AddRequirement(s.requirements, "blob", "mat_dirt", "Dirt", 200);
-		AddRequirement(s.requirements, "blob", "grain", "Grain", 1); 
-		AddRequirement(s.requirements, "blob", "mat_mithrilingot", "Mithril Ingot", 1);
-		//Requiring grain and a mithrilg ingot means its a lot harder to spawm since both of these ressources are harder to get on mass (instead of dirt wood and coins alone)
+		AddRequirement(s.requirements, "blob", "grain", "Grain", 2); 
+		AddRequirement(s.requirements, "blob", "mat_mithril", "Mithril", 50);
 		s.spawnNothing = true;
 	}
 }

--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Nursery/Nursery.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Nursery/Nursery.as
@@ -90,9 +90,7 @@ void onInit(CBlob@ this)
 		ShopItem@ s = addShopItem(this, "Kudzu Core", "$kudzucore$", "kudzucore", "Creates a kudzu core a quickly spreading plant which slowy damages other things, Cannot be stored", true);
 		AddRequirement(s.requirements, "blob", "mat_wood", "Wood", 500);
 		AddRequirement(s.requirements, "blob", "mat_dirt", "Dirt", 200);
-		AddRequirement(s.requirements, "blob", "grain", "Grain", 1); 
-		AddRequirement(s.requirements, "blob", "mat_mithrilingot", "Mithril Ingot", 1);
-		//Requiring grain and a mithrilg ingot means its a lot harder to spawm since both of these ressources are harder to get on mass (instead of dirt wood and coins alone)
+		AddRequirement(s.requirements, "coin", "", "Coins", 100);
 		s.spawnNothing = true;
 	}
 }


### PR DESCRIPTION
-Nursery can now create seeds from only coins and wood, OR from the plant 
-Kudzu core price reduced to 2 grain and 50 mithril 

This is first up to make farming slightly more viable since it desperately needs any buff and also to make plants more replenishable on destroyed maps
The second is to make kudzu core more reachable by not requiring a witch hut since they haven't seen viable use as well.