### PR TITLE
Fixed vehicles' unreasonable bullet-count on server

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Turret/Sentry.as
@@ -212,7 +212,8 @@ void onTick(CBlob@ this)
 					f32 angle = -dir.Angle() + (this.isFacingLeft() ? 180 : 0);
 					angle += ((XORRandom(400) - 200) / 100.0f);
 
-					if (isServer())
+					CPlayer@ firstPlayer = getPlayer(0); //hack
+					if (firstPlayer !is null && firstPlayer.isMyPlayer())
 					{
 						GunSettings@ settings;
 						this.get("gun_settings", @settings);

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Coilgun/Coilgun.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Coilgun/Coilgun.as
@@ -203,22 +203,19 @@ u16 GetAmmo(CBlob@ this)
 
 void Shoot(CBlob@ this, f32 angle)
 {
-	if (isServer())
+	angle = angle * (this.isFacingLeft() ? -1 : 1);
+
+	GunSettings@ settings;
+	this.get("gun_settings", @settings);
+
+	// Muzzle
+	Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x / 3) * (this.isFacingLeft() ? 1 : -1), settings.MUZZLE_OFFSET.y + 1);
+	fromBarrel = fromBarrel.RotateBy(angle);
+
+	CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
+	if (gunner !is null && gunner.isMyPlayer())
 	{
-		angle = angle * (this.isFacingLeft() ? -1 : 1);
-
-		GunSettings@ settings;
-		this.get("gun_settings", @settings);
-
-		// Muzzle
-		Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x / 3) * (this.isFacingLeft() ? 1 : -1), settings.MUZZLE_OFFSET.y + 1);
-		fromBarrel = fromBarrel.RotateBy(angle);
-
-		CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
-		if (gunner !is null)
-		{
-			shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
-		}
+		shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
 	}
 
 	if (isClient())

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/GatlingGun/GatlingGun.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/GatlingGun/GatlingGun.as
@@ -209,20 +209,17 @@ void Vehicle_onFire(CBlob@ this, VehicleInfo@ v, CBlob@ bullet, const u8 _unused
 	angle *= this.isFacingLeft() ? -1 : 1;
 	angle += ((XORRandom(400) - 150) / 100.0f);
 
-	if (isServer())
+	GunSettings@ settings;
+	this.get("gun_settings", @settings);
+
+	// Muzzle
+	Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x / 3) * (this.isFacingLeft() ? 1 : -1), settings.MUZZLE_OFFSET.y + 1);
+	fromBarrel = fromBarrel.RotateBy(angle);
+
+	CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
+	if (gunner !is null && gunner.isMyPlayer())
 	{
-		GunSettings@ settings;
-		this.get("gun_settings", @settings);
-
-		// Muzzle
-		Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x / 3) * (this.isFacingLeft() ? 1 : -1), settings.MUZZLE_OFFSET.y + 1);
-		fromBarrel = fromBarrel.RotateBy(angle);
-
-		CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
-		if (gunner !is null)
-		{
-			shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
-		}
+		shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
 	}
 
 	if (isClient())

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Helichopper/Helichopper.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Helichopper/Helichopper.as
@@ -632,23 +632,20 @@ void renderAmmo(CBlob@ blob, bool rocket)
 
 void ShootGun(CBlob@ this, f32 angle, Vec2f gunPos)
 {
-	if (isServer())
+	f32 sign = (this.isFacingLeft() ? -1 : 1);
+	angle += ((XORRandom(400) - 100) / 100.0f);
+	angle += this.getAngleDegrees();
+
+	GunSettings@ settings;
+	this.get("gun_settings", @settings);
+
+	Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x + 5) * -sign, settings.MUZZLE_OFFSET.y);
+	fromBarrel.RotateBy(this.getAngleDegrees());
+
+	CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
+	if (gunner !is null && gunner.isMyPlayer())
 	{
-		f32 sign = (this.isFacingLeft() ? -1 : 1);
-		angle += ((XORRandom(400) - 100) / 100.0f);
-		angle += this.getAngleDegrees();
-
-		GunSettings@ settings;
-		this.get("gun_settings", @settings);
-
-		Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x + 5) * -sign, settings.MUZZLE_OFFSET.y);
-		fromBarrel.RotateBy(this.getAngleDegrees());
-
-		CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
-		if (gunner !is null)
-		{
-			shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
-		}
+		shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
 	}
 
 	if (isClient())

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/MachineGun/MachineGun.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/MachineGun/MachineGun.as
@@ -214,20 +214,17 @@ void Vehicle_onFire(CBlob@ this, VehicleInfo@ v, CBlob@ bullet, const u8 _unused
 	angle *= (this.isFacingLeft() ? -1 : 1);
 	angle += ((XORRandom(300) - 100) / 100.0f);
 
-	if (isServer())
+	GunSettings@ settings;
+	this.get("gun_settings", @settings);
+
+	// Muzzle
+	Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x / 3) * (this.isFacingLeft() ? 1 : -1), settings.MUZZLE_OFFSET.y + 1);
+	fromBarrel = fromBarrel.RotateBy(angle);
+
+	CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
+	if (gunner !is null && gunner.isMyPlayer())
 	{
-		GunSettings@ settings;
-		this.get("gun_settings", @settings);
-
-		// Muzzle
-		Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x / 3) * (this.isFacingLeft() ? 1 : -1), settings.MUZZLE_OFFSET.y + 1);
-		fromBarrel = fromBarrel.RotateBy(angle);
-
-		CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
-		if (gunner !is null)
-		{
-			shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
-		}
+		shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
 	}
 
 	if (isClient())

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Minicopter/Minicopter.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Minicopter/Minicopter.as
@@ -203,8 +203,7 @@ void onTick(CBlob@ this)
 
 							if (pressed_m1 && isClient())
 							{
-								CBlob@ realPlayer = getLocalPlayerBlob();
-								if (getGameTime() > this.get_u32("fireDelayGun") && realPlayer !is null && realPlayer is hooman)
+								if (getGameTime() > this.get_u32("fireDelayGun") && hooman.isMyPlayer())
 								{
 									CBitStream params;
 									params.write_s32(this.get_f32("gunAngle"));

--- a/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Triplane/Triplane.as
+++ b/TFlippy_TerritoryControl_Weapons_Dev/Entities/Vehicles/Triplane/Triplane.as
@@ -218,20 +218,17 @@ void Shoot(CBlob@ this)
 	GunSettings@ settings;
 	this.get("gun_settings", @settings);
 
-	if (isServer())
+	// Angle shittery
+	f32 angle = this.getAngleDegrees() + ((XORRandom(500) - 100) / 100.0f);
+
+	// Muzzle
+	Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x / 3) * (this.isFacingLeft() ? 1 : -1), settings.MUZZLE_OFFSET.y + 1);
+	fromBarrel = fromBarrel.RotateBy(angle);
+
+	CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
+	if (gunner !is null && gunner.isMyPlayer())
 	{
-		// Angle shittery
-		f32 angle = this.getAngleDegrees() + ((XORRandom(500) - 100) / 100.0f);
-
-		// Muzzle
-		Vec2f fromBarrel = Vec2f((settings.MUZZLE_OFFSET.x / 3) * (this.isFacingLeft() ? 1 : -1), settings.MUZZLE_OFFSET.y + 1);
-		fromBarrel = fromBarrel.RotateBy(angle);
-
-		CBlob@ gunner = this.getAttachmentPoint(0).getOccupied();
-		if (gunner !is null)
-		{
-			shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
-		}
+		shootGun(this.getNetworkID(), angle, gunner.getNetworkID(), this.getPosition() + fromBarrel);
 	}
 
 	if (isClient())


### PR DESCRIPTION
The issue was caused by commands being sent from all players on the server. This PR adds a ``isMyPlayer()`` check to every instance where vehicles shoot, which solves the bug.