### PR TITLE
Bulk Forges

### DIFF
--- a/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/AutoForge/AutoForge.as
+++ b/TFlippy_TerritoryControl_Structures_Dev/Entities/Structures/Factories/AutoForge/AutoForge.as
@@ -10,73 +10,90 @@ const string[] matNames = {
 	"mat_copper",
 	"mat_iron",
 	"mat_gold",
-	"mat_wood"
+	"mat_wood",
+	"mat_ironingot"
 };
 
 const string[] matNamesResult = { 
 	"mat_copperingot",
 	"mat_ironingot",
 	"mat_goldingot",
-	"mat_coal"
+	"mat_coal",
+	"mat_steelingot"
 };
 
 const int[] matRatio = { 
 	5,
 	5,
 	25,
-	10
+	10,
+	2
 };
 
 const int[] matResult = { 
 	1,
 	1,
 	2,
+	1,
 	1
+};
+
+const int[] coalRatio = {
+	0,
+	0,
+	0,
+	0,
+	2
 };
 
 void onInit(CBlob@ this)
 {
 	this.set_TileType("background tile", CMap::tile_castle_back);
 	this.getShape().getConsts().mapCollisions = false;
+	this.getCurrentScript().tickFrequency = 60;
 
 	this.Tag("builder always hit");
+	this.set_u16("bulk_modifier", 2);
 }
 
 void onTick(CBlob@ this)
 {
-	this.getCurrentScript().tickFrequency = 60 / (this.exists("gyromat_acceleration") ? this.get_f32("gyromat_acceleration") : 1);
-	
-	if (this.hasBlob("mat_ironingot", 2) && this.hasBlob("mat_coal", 2)) //steel ingots require coal to be created
+	f32 gyro = this.get_f32("gyromat_acceleration");
+	if (gyro > 2) // if gyro > 200% then start bulk production
 	{
-		if (isServer())
-		{
-			CBlob@ mat = server_CreateBlob("mat_steelingot", -1, this.getPosition());
-			mat.server_SetQuantity(1);
-			mat.Tag("justmade");
-			this.TakeBlob("mat_ironingot", 2);
-			this.TakeBlob("mat_coal", 2);
-		}
-		if (isClient())
-		{
-			this.getSprite().PlaySound("ProduceSound.ogg");
-			this.getSprite().PlaySound("BombMake.ogg");
-		}
+		gyro /= 2;
+		this.set_u16("bulk_modifier", gyro*2);
 	}
-	for (int i = 0; i < matNames.length; i++)
+	else this.set_u16("bulk_modifier", 2);
+
+	this.getCurrentScript().tickFrequency = Maths::Max(60/gyro, 15);
+
+	CInventory@ inv = this.getInventory();
+	if (inv !is null)
 	{
-		if (this.hasBlob(matNames[i], matRatio[i]))
+		for (u8 i = 0; i < 5; i++)
 		{
-			if (isServer())
+			u8 bulk = Maths::Min(inv.getCount(matNames[i])/matRatio[i], this.get_u16("bulk_modifier") - (i == 2 ? 1 : 0)); // because gold has dif matResult
+			if (bulk > 0)
 			{
-				CBlob@ mat = server_CreateBlob(matNamesResult[i], -1, this.getPosition());
-				mat.server_SetQuantity(matResult[i]);
-				mat.Tag("justmade");
-				this.TakeBlob(matNames[i], matRatio[i]);
-			}
-			if (isClient())
-			{
-				this.getSprite().PlaySound("ProduceSound.ogg");
-				this.getSprite().PlaySound("BombMake.ogg");
+				if (coalRatio[i] > 0) bulk = Maths::Min(inv.getCount("mat_coal")/coalRatio[i], bulk);
+				if (this.hasBlob(matNames[i], matRatio[i]*bulk) && (coalRatio[i] == 0 || this.hasBlob("mat_coal", coalRatio[i]*bulk)))
+				{
+					if (isServer())
+					{
+						CBlob @mat = server_CreateBlob(matNamesResult[i], -1, this.getPosition());
+						mat.server_SetQuantity(matResult[i]*bulk);
+						mat.Tag("justmade");
+						this.TakeBlob(matNames[i], matRatio[i]*bulk);
+						if (coalRatio[i] > 0) this.TakeBlob("mat_coal", coalRatio[i]*bulk);
+					}
+
+					if (isClient())
+					{
+						this.getSprite().PlaySound("ProduceSound.ogg");
+						this.getSprite().PlaySound("BombMake.ogg");
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- less laggy factories
- Forges now uses a simple logic in which it produces ingots in bulk
- this only applies to 600% gyromats or more
- no change to production speed
- in bulking mode, half the speed is used for bulking and half is used as speed
- example: instead of 4 ingots per 0.1 sec it produces 8 ingots per 0.2 sec